### PR TITLE
fix an unneeded use that may cause conflicts

### DIFF
--- a/src/Access/ApprovePrivateDiscussions.php
+++ b/src/Access/ApprovePrivateDiscussions.php
@@ -2,7 +2,6 @@
 
 namespace Flagrow\Byobu\Access;
 
-use Flarum\Core\Access\AbstractPolicy;
 use Flarum\Core\Discussion;
 use Flarum\Core\User;
 


### PR DESCRIPTION
Use statment is not needed considering class is loaded from same namespace, may cause conflicts.