### PR TITLE
fix: console error when loading PrivateDiscussionComposer if DiscussionComposer not already loaded

### DIFF
--- a/js/src/forum/extenders/extendUserComponents.tsx
+++ b/js/src/forum/extenders/extendUserComponents.tsx
@@ -24,13 +24,19 @@ export default function extendUserComponents() {
             recipients.add('users:' + app.session.user!.id(), app.session.user!);
             recipients.add('users:' + user.id(), user);
 
-            await app.composer.load(() => import('../pages/discussions/PrivateDiscussionComposer'), {
-              user: app.session.user,
-              recipients: recipients,
-              recipientUsers: recipients,
-              titlePlaceholder: app.translator.trans('fof-byobu.forum.composer_private_discussion.title_placeholder'),
-              submitLabel: app.translator.trans('fof-byobu.forum.composer_private_discussion.submit_button'),
-            });
+            await app.composer.load(
+              () =>
+                import('flarum/forum/components/DiscussionComposer').then(async () => {
+                  return await import('../pages/discussions/PrivateDiscussionComposer');
+                }),
+              {
+                user: app.session.user,
+                recipients: recipients,
+                recipientUsers: recipients,
+                titlePlaceholder: app.translator.trans('fof-byobu.forum.composer_private_discussion.title_placeholder'),
+                submitLabel: app.translator.trans('fof-byobu.forum.composer_private_discussion.submit_button'),
+              }
+            );
 
             app.composer.show();
           }}


### PR DESCRIPTION


<!--
IMPORTANT: We LOVE seeing new pull requests, they excite us every single time they are submitted! As we have an obligation to maintain a healthy code standard, quality, and extensions, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #0000**

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).

**Required changes:**

- [ ] Related [Flarum core extension PR's](https://github.com/flarum/core/pulls): (Omit this section if irrelevant)
