### PR TITLE
fix: prevent N+1 queries by using eager loaded data in Screener

### DIFF
--- a/src/Discussion/Screener.php
+++ b/src/Discussion/Screener.php
@@ -34,9 +34,9 @@ class Screener extends Fluent
         $screener = new self();
 
         /** @phpstan-ignore-next-line */
-        $screener->users = $screener->currentUsers = $discussion->recipientUsers()->get();
+        $screener->users = $screener->currentUsers = $discussion->recipientUsers;
         /** @phpstan-ignore-next-line */
-        $screener->groups = $screener->currentGroups = $discussion->recipientGroups()->get();
+        $screener->groups = $screener->currentGroups = $discussion->recipientGroups;
 
         return $screener;
     }


### PR DESCRIPTION
<!--
IMPORTANT: We LOVE seeing new pull requests, they excite us every single time they are submitted! As we have an obligation to maintain a healthy code standard, quality, and extensions, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #228**

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->
Modified `src/Discussion/Screener.php` to access relationships via properties (e.g., `$discussion->recipientUsers`) instead of method calls.
This ensures that the pre-loaded data from `extend.php` is used efficiently.

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->
Before:
<img width="1346" height="884" alt="PixPin_2026-02-16_16-05-16" src="https://github.com/user-attachments/assets/7ce7a8bb-b01e-45c3-87b9-eb4ed95474dc" />

After:
<img width="1363" height="319" alt="PixPin_2026-02-16_16-04-35" src="https://github.com/user-attachments/assets/03838f71-45ef-4440-97cc-7b266db1d581" />

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).

**Required changes:**

- [ ] Related [Flarum core extension PR's](https://github.com/flarum/core/pulls): (Omit this section if irrelevant)
