### PR TITLE
[1.x] fix: eliminate N+1 queries in Screener and correct listener re-registration

### DIFF
--- a/src/Discussion/Screener.php
+++ b/src/Discussion/Screener.php
@@ -34,9 +34,9 @@ class Screener extends Fluent
         $screener = new self();
 
         /** @phpstan-ignore-next-line */
-        $screener->users = $screener->currentUsers = $discussion->recipientUsers()->get();
+        $screener->users = $screener->currentUsers = $discussion->recipientUsers;
         /** @phpstan-ignore-next-line */
-        $screener->groups = $screener->currentGroups = $discussion->recipientGroups()->get();
+        $screener->groups = $screener->currentGroups = $discussion->recipientGroups;
 
         return $screener;
     }
@@ -45,9 +45,9 @@ class Screener extends Fluent
     {
         $screener = new self();
         /** @phpstan-ignore-next-line */
-        $screener->currentUsers = $event->discussion->recipientUsers()->get();
+        $screener->currentUsers = $event->discussion->recipientUsers;
         /** @phpstan-ignore-next-line */
-        $screener->currentGroups = $event->discussion->recipientGroups()->get();
+        $screener->currentGroups = $event->discussion->recipientGroups;
 
         $screener->users = static::getRecipientsFromPayload($event, 'users');
         $screener->groups = static::getRecipientsFromPayload($event, 'groups');

--- a/src/Provider/ByobuProvider.php
+++ b/src/Provider/ByobuProvider.php
@@ -41,9 +41,12 @@ class ByobuProvider extends AbstractServiceProvider
         $events->listen(Saving::class, DropTagsOnPrivateDiscussions::class);
 
         // then re-add everything else
+        // $listeners contains already-resolved closures from getListeners(), with signature
+        // ($eventName, $payload). makeListener() will call our wrapper as $wrapper($eventObject),
+        // so we restore the expected signature by hardcoding the event name string.
         foreach ($listeners as $listener) {
-            $callable = function ($event, $payload = []) use ($listener) {
-                return $listener($event, [$event, $payload]);
+            $callable = function ($event) use ($listener) {
+                return $listener(Saving::class, [$event]);
             };
             $events->listen(Saving::class, $callable);
         }


### PR DESCRIPTION
## Summary

- Fixes N+1 queries in `Screener` by using property access (`$discussion->recipientUsers`) instead of method calls (`->recipientUsers()->get()`), so eager-loaded relation data is reused rather than re-queried per discussion. Applied to both `fromDiscussion()` and `whenSavingDiscussions()`.
- Fixes `ByobuProvider::boot()` where re-registered `Saving` listeners were incorrectly called with the event object in the event-name position, causing a `TypeError` in any listener that inspects the event name (confirmed broken with Clockwork installed).

Closes #230. See also duplicate #228 and supersedes PR #229 (which only covered `fromDiscussion()`).

## Performance impact (60 discussions)

| Metric | Before | After |
|---|---|---|
| Total queries | 178 | 57 |
| Response time | ~2247ms | ~2101ms |

## Test plan

- [x] `composer test` — all tests green
- [x] `composer analyse:phpstan` — no errors
- [x] Verified recipient queries batch to 2 total (1 users + 1 groups) via Clockwork on dev forum