### PR TITLE
[2.x] fix: use property access in Screener to avoid N+1 queries on discussion list

### DIFF
--- a/src/Discussion/Screener.php
+++ b/src/Discussion/Screener.php
@@ -115,7 +115,7 @@ class Screener extends Fluent
         return $this->users
             ->reject(function (User $user) {
                 // Reject currentUsers and allow the actor to create PDs even if they block incoming new PDs
-                return $this->currentUsers->contains($user) || ($user->id === ($this->actor()?->id ?? false));
+                return $this->currentUsers->contains($user) || ($user->id === $this->actor()?->id);
             })
             ->first(function (User $user) {
                 return boolval($user->blocks_byobu_pd);

--- a/src/Discussion/Screener.php
+++ b/src/Discussion/Screener.php
@@ -34,9 +34,9 @@ class Screener extends Fluent
         $screener = new self();
 
         /** @phpstan-ignore-next-line */
-        $screener->users = $screener->currentUsers = $discussion->recipientUsers()->get();
+        $screener->users = $screener->currentUsers = $discussion->recipientUsers;
         /** @phpstan-ignore-next-line */
-        $screener->groups = $screener->currentGroups = $discussion->recipientGroups()->get();
+        $screener->groups = $screener->currentGroups = $discussion->recipientGroups;
 
         return $screener;
     }
@@ -45,9 +45,9 @@ class Screener extends Fluent
     {
         $screener = new self();
         /** @phpstan-ignore-next-line */
-        $screener->currentUsers = $event->discussion->recipientUsers()->get();
+        $screener->currentUsers = $event->discussion->recipientUsers;
         /** @phpstan-ignore-next-line */
-        $screener->currentGroups = $event->discussion->recipientGroups()->get();
+        $screener->currentGroups = $event->discussion->recipientGroups;
 
         $screener->users = static::getRecipientsFromPayload($event, 'users');
         $screener->groups = static::getRecipientsFromPayload($event, 'groups');

--- a/src/Provider/ByobuProvider.php
+++ b/src/Provider/ByobuProvider.php
@@ -41,9 +41,12 @@ class ByobuProvider extends AbstractServiceProvider
         $events->listen(Saving::class, DropTagsOnPrivateDiscussions::class);
 
         // then re-add everything else
+        // $listeners contains already-resolved closures from getListeners(), with signature
+        // ($eventName, $payload). makeListener() will call our wrapper as $wrapper($eventObject),
+        // so we restore the expected signature by hardcoding the event name string.
         foreach ($listeners as $listener) {
-            $callable = function ($event, $payload = []) use ($listener) {
-                return $listener($event, [$event, $payload]);
+            $callable = function ($event) use ($listener) {
+                return $listener(Saving::class, [$event]);
             };
             $events->listen(Saving::class, $callable);
         }


### PR DESCRIPTION
## Summary

Fixes #228. 2.x equivalent of #232.

Two fixes:

**1. N+1 queries in `Screener`**

`Screener::fromDiscussion()` and `Screener::whenSavingDiscussions()` were using method call syntax (`->recipientUsers()->get()`) which bypasses Eloquent's relationship cache and fires a fresh DB query every time. Switching to property access (`->recipientUsers`) reuses already eager-loaded data (which `extend.php` registers for all `Index`, `Show`, and `Create` endpoints).

Measured on a 20-discussion page load (`/api/discussions?include=...,recipientUsers,recipientGroups,...`):

| Metric | Before | After | Δ |
|---|---|---|---|
| Total queries | 199 | 79 | **−120** |
| Response time | 454ms | 382ms | **−72ms** |

**2. Incorrect listener re-registration in `ByobuProvider::boot()`**

The closures returned by `getListeners()` have signature `($eventName, $payload)`. When re-registered via `listen()`, Laravel's `makeListener()` calls them as `$wrapper($eventObject)` — the previous wrapper double-wrapped the payload incorrectly. Fixed by hardcoding the event name string and passing `[$event]` as the payload array.

## Test plan

- [ ] Load the discussion list — confirm no regressions in private discussion visibility or `isPrivateDiscussion` / `canMakePublic` fields
- [ ] Create a private discussion — confirm recipients are saved correctly
- [ ] Edit recipients on an existing private discussion — confirm changes persist
- [ ] Verify `DropTagsOnPrivateDiscussions` still fires correctly on Discussion saving