### PR TITLE
[2.x] fix: resolve issues with hide-PD-from-all-discussions feature

### DIFF
--- a/extend.php
+++ b/extend.php
@@ -73,7 +73,7 @@ return [
         }),
 
     (new Extend\ApiResource(Resource\DiscussionResource::class))
-        ->fieldsBefore('tags', Api\DiscussionResourceFields::class)
+        ->fields(Api\DiscussionResourceFields::class)
         ->field('tags', fn (Schema\Relationship\ToMany $field) => $field->writable(function (Discussion $discussion, Context $context) {
             return empty(Arr::get($context->body(), 'data.relationships.recipientUsers.data'))
                 && empty(Arr::get($context->body(), 'data.relationships.recipientGroups.data'));

--- a/migrations/2021_01_13_000000_unified_index_index.php
+++ b/migrations/2021_01_13_000000_unified_index_index.php
@@ -11,7 +11,6 @@
 
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Schema\Builder;
-use Illuminate\Support\Arr;
 
 return [
     'up' => function (Builder $schema) {
@@ -20,20 +19,13 @@ return [
         });
     },
     'down' => function (Builder $schema) {
-        $schema->table('users', function (Blueprint $table) use ($schema) {
-            $connection = $schema->getConnection();
-            $schemaManager = $connection->getDoctrineSchemaManager();
-            $existingIndexes = $schemaManager->listTableIndexes($table->getTable());
+        // If migration 2021_04_21_000000_drop_users_unified_index_column has already been applied,
+        // the column (and its index) no longer exist — skip gracefully.
+        if (!$schema->hasIndex('users', ['unified_index_with_byobu'])) {
+            return;
+        }
 
-            // If migration 2021_04_21_000000_drop_users_unified_index_column has been applied, this index already no longer exists
-            // Unfortunately we can't call the protected createIndexName method so we have to build the index name manually
-            $indexName = strtolower(str_replace(['-', '.'], '_', $connection->getTablePrefix().$table->getTable()).'_unified_index_with_byobu_index');
-
-            if (!Arr::exists($existingIndexes, $indexName)) {
-                return;
-            }
-
-            // Use array syntax so the blueprint "guesses" the full index name
+        $schema->table('users', function (Blueprint $table) {
             $table->dropIndex(['unified_index_with_byobu']);
         });
     },

--- a/src/Filters/Discussion/HidePrivateDiscussionsFromAllDiscussionsPage.php
+++ b/src/Filters/Discussion/HidePrivateDiscussionsFromAllDiscussionsPage.php
@@ -33,10 +33,15 @@ class HidePrivateDiscussionsFromAllDiscussionsPage
             return;
         }
 
-        // Use a JOIN instead of a subquery because we don't want to extract the list of all PD IDs from the entire forum
-        // Use an alias for the recipients table to avoir errors with other features or extension that might also join the table
+        // Use NOT EXISTS rather than LEFT JOIN + whereNull to avoid making bare column references
+        // in other extensions' SELECT expressions ambiguous when MySQL resolves them across
+        // multiple joined tables (e.g. flarum/sticky's is_unread_sticky expression). The
+        // optimizer treats these patterns equivalently so there is no performance trade-off.
         $filter->getQuery()
-            ->leftJoin('recipients as adp_recipients', 'adp_recipients.discussion_id', '=', 'discussions.id')
-            ->whereNull('adp_recipients.discussion_id');
+            ->whereNotExists(function ($query) {
+                $query->selectRaw('1')
+                    ->from('recipients')
+                    ->whereColumn('recipients.discussion_id', 'discussions.id');
+            });
     }
 }

--- a/tests/integration/api/HideFromAllDiscussionsPageDisabledTest.php
+++ b/tests/integration/api/HideFromAllDiscussionsPageDisabledTest.php
@@ -1,0 +1,135 @@
+<?php
+
+/*
+ * This file is part of fof/byobu.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FoF\Byobu\Tests\integration\api;
+
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\Testing\integration\TestCase;
+use Flarum\User\User;
+use PHPUnit\Framework\Attributes\Test;
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * Fixture layout:
+ *   - User 2 (normal): a recipient of discussion 2 (the private one)
+ *   - Discussion 1: public (is_private = 0, no recipients row)
+ *   - Discussion 2: private (is_private = 1, user 2 is a recipient)
+ *
+ * Two concrete test classes below boot the app with the setting OFF and ON
+ * respectively. They are separate classes so each gets a fresh app instance,
+ * avoiding any settings-cache cross-contamination between tests.
+ */
+
+/**
+ * Setting DISABLED (default) — private discussion should still appear in the list.
+ */
+class HideFromAllDiscussionsPageDisabledTest extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->extension('fof-byobu');
+
+        $this->prepareDatabase([
+            User::class => [
+                $this->normalUser(),
+            ],
+            'discussions' => [
+                ['id' => 1, 'title' => 'Public Discussion', 'slug' => 'public-discussion', 'comment_count' => 1, 'participant_count' => 1, 'created_at' => '2024-01-01 00:00:00', 'last_posted_at' => '2024-01-01 00:00:00', 'is_private' => 0, 'user_id' => 1],
+                ['id' => 2, 'title' => 'Private Discussion', 'slug' => 'private-discussion', 'comment_count' => 1, 'participant_count' => 1, 'created_at' => '2024-01-01 00:00:00', 'last_posted_at' => '2024-01-01 00:00:00', 'is_private' => 1, 'user_id' => 1],
+            ],
+            'recipients' => [
+                ['id' => 1, 'discussion_id' => 2, 'user_id' => 2, 'group_id' => null, 'created_at' => '2024-01-01 00:00:00', 'updated_at' => '2024-01-01 00:00:00', 'removed_at' => null],
+            ],
+        ]);
+    }
+
+    #[Test]
+    public function private_discussion_is_visible_in_list_when_setting_is_disabled(): void
+    {
+        $response = $this->send(
+            $this->request('GET', '/api/discussions', [
+                'authenticatedAs' => 2,
+            ])
+        );
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $ids = $this->discussionIds($response);
+
+        $this->assertContains(2, $ids, 'Private discussion should be visible when setting is off');
+        $this->assertContains(1, $ids, 'Public discussion should be visible when setting is off');
+    }
+
+    private function discussionIds(ResponseInterface $response): array
+    {
+        $json = json_decode($response->getBody()->getContents(), true);
+
+        return array_map(fn ($d) => (int) $d['id'], $json['data'] ?? []);
+    }
+}
+
+/**
+ * Setting ENABLED — private discussions should be hidden from the list.
+ */
+class HideFromAllDiscussionsPageEnabledTest extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->extension('fof-byobu');
+
+        $this->setting('fof-byobu.hide_from_all_discussions_page', '1');
+
+        $this->prepareDatabase([
+            User::class => [
+                $this->normalUser(),
+            ],
+            'discussions' => [
+                ['id' => 1, 'title' => 'Public Discussion', 'slug' => 'public-discussion', 'comment_count' => 1, 'participant_count' => 1, 'created_at' => '2024-01-01 00:00:00', 'last_posted_at' => '2024-01-01 00:00:00', 'is_private' => 0, 'user_id' => 1],
+                ['id' => 2, 'title' => 'Private Discussion', 'slug' => 'private-discussion', 'comment_count' => 1, 'participant_count' => 1, 'created_at' => '2024-01-01 00:00:00', 'last_posted_at' => '2024-01-01 00:00:00', 'is_private' => 1, 'user_id' => 1],
+            ],
+            'recipients' => [
+                ['id' => 1, 'discussion_id' => 2, 'user_id' => 2, 'group_id' => null, 'created_at' => '2024-01-01 00:00:00', 'updated_at' => '2024-01-01 00:00:00', 'removed_at' => null],
+            ],
+        ]);
+    }
+
+    #[Test]
+    public function private_discussion_is_hidden_from_list_when_setting_is_enabled(): void
+    {
+        $response = $this->send(
+            $this->request('GET', '/api/discussions', [
+                'authenticatedAs' => 2,
+            ])
+        );
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $ids = $this->discussionIds($response);
+
+        $this->assertNotContains(2, $ids, 'Private discussion should be hidden when setting is on');
+        $this->assertContains(1, $ids, 'Public discussion should still be visible when setting is on');
+    }
+
+    private function discussionIds(ResponseInterface $response): array
+    {
+        $json = json_decode($response->getBody()->getContents(), true);
+
+        return array_map(fn ($d) => (int) $d['id'], $json['data'] ?? []);
+    }
+}


### PR DESCRIPTION
Fixes #236.

## Changes

**`NOT EXISTS` instead of `LEFT JOIN` in `HidePrivateDiscussionsFromAllDiscussionsPage`**

The LEFT JOIN caused MySQL to raise `Column 'id' in where clause is ambiguous` when other extensions add bare column references to the outer SELECT (e.g. flarum/sticky's `is_unread_sticky` expression). Switching to a `NOT EXISTS` correlated subquery avoids adding any tables to the outer query's context. The two approaches are semantically equivalent and the optimizer treats them the same way.

The sticky-side fix has been filed at flarum/framework#4519.

**Fix `getDoctrineSchemaManager()` in migration down()**

The `2021_01_13_000000_unified_index_index` migration called `$connection->getDoctrineSchemaManager()` to check whether an index existed before dropping it. Doctrine DBAL was removed in Laravel 10+, so this threw a fatal error when purging the extension. The partial rollback left migrations in a broken state that prevented re-enabling. Replaced with `$schema->hasIndex()`.

**`->fields()` instead of `->fieldsBefore('tags', ...)`**

`fieldsBefore` silently drops all new fields when the anchor field (`tags`) doesn't exist (i.e. flarum/tags is not installed). This meant `recipientUsers`/`recipientGroups` were never registered as includable, causing 400 errors on any discussion list request. Changed to `->fields()` which always appends.