### PR TITLE
[1.x] fix: private discussion visibility race window, self-exclusion, and permission bugs

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -8,6 +8,6 @@ jobs:
     with:
       enable_backend_testing: true
       enable_phpstan: true
-      php_versions: '["8.0", "8.1", "8.2", "8.3"]'
+      php_versions: '["8.0", "8.1", "8.2", "8.3", "8.4", "8.5"]'
 
       backend_directory: .

--- a/composer.json
+++ b/composer.json
@@ -13,11 +13,11 @@
     "authors": [
         {
             "name": "Daniël Klabbers",
-            "email": "daniel@blomstra.net"
+            "role": "Developer"
         },
         {
             "name": "IanM",
-            "email": "ian@blomstra.net",
+            "email": "ian@flarum.org",
             "role": "Developer"
         }
     ],
@@ -78,7 +78,8 @@
         "fof/split": "*",
         "flarum/flags": "*",
         "flarum/phpstan": "*",
-        "flarum/testing": "^1.0.0"
+        "flarum/testing": "^1.0.0",
+        "flarum/tags": "^1.8"
     },
     "scripts": {
         "analyse:phpstan": "phpstan analyse",

--- a/src/Gambits/User/AllowsPdGambit.php
+++ b/src/Gambits/User/AllowsPdGambit.php
@@ -46,7 +46,7 @@ class AllowsPdGambit extends AbstractRegexGambit
 
         $this->dispatcher->dispatch(new SearchingRecipient($search, $matches, $negate));
 
-        if ($actor->can('startPrivateDiscussionWithBlockers')) {
+        if ($actor->can('discussion.startPrivateDiscussionWithBlockers')) {
             return;
         }
 

--- a/src/Listeners/DropTagsOnPrivateDiscussions.php
+++ b/src/Listeners/DropTagsOnPrivateDiscussions.php
@@ -29,8 +29,8 @@ class DropTagsOnPrivateDiscussions
 
     public function handle(Saving $event)
     {
-        $isByobu = Arr::exists($event->data, 'relationships.recipientUsers') || Arr::exists($event->data, 'relationships.recipientGroups');
-        $hasTags = Arr::exists($event->data, 'relationships.tags.data');
+        $isByobu = Arr::has($event->data, 'relationships.recipientUsers') || Arr::has($event->data, 'relationships.recipientGroups');
+        $hasTags = Arr::has($event->data, 'relationships.tags.data');
 
         if ($isByobu
             && $hasTags

--- a/src/Listeners/PersistRecipients.php
+++ b/src/Listeners/PersistRecipients.php
@@ -68,38 +68,36 @@ class PersistRecipients
             throw new PermissionDeniedException('Not allowed to convert to a public discussion');
         }
 
-        if ($event->actor->cannot('addMoreThanTwoUserRecipients', $event->discussion) && $this->screener->users->count() > 2) {
-            throw new PermissionDeniedException('Not allowed to add more than 2 user recipients');
-        }
-
         if (!$event->discussion->exists) {
             $this->checkPermissionsForNewDiscussion($event->actor);
             $event->discussion->isByobu = true;
 
-            // Set is_private immediately so the first INSERT writes is_private=1,
-            // closing the race window where the discussion is briefly visible to
-            // non-recipients (issue #239).
-            //
-            // Also pre-populate the relation cache on this $discussion object so
-            // all subsequent saves on the same stale instance (e.g. the final save
-            // in StartDiscussionHandler) also see non-empty recipients and keep
-            // is_private=1 rather than resetting it to 0.
-            //
             // Ensure the actor is always included as a user recipient (issue #168).
-            // This is required both so they can read their own discussion and so that
-            // core's PostReplyHandler can find the discussion via scoped visibility
-            // between the INSERT and the afterSave that writes recipient rows.
-            if ($this->screener->isPrivate()) {
-                if (!$this->screener->users->contains($event->actor)) {
-                    $this->screener->users = $this->screener->users->concat([$event->actor]);
-                }
-
-                $event->discussion->is_private = true;
-                $event->discussion->setRelation('recipientUsers', $this->screener->users);
-                $event->discussion->setRelation('recipientGroups', $this->screener->groups);
+            // Must happen before the addMoreThanTwoUserRecipients check so that
+            // the limit is evaluated against the true final recipient count.
+            if ($this->screener->isPrivate() && !$this->screener->users->contains($event->actor)) {
+                $this->screener->users = $this->screener->users->concat([$event->actor]);
             }
         } else {
             $this->checkPermissionsForExistingDiscussion($event->actor, $event->discussion);
+        }
+
+        if ($event->actor->cannot('addMoreThanTwoUserRecipients', $event->discussion) && $this->screener->users->count() > 2) {
+            throw new PermissionDeniedException('Not allowed to add more than 2 user recipients');
+        }
+
+        // Set is_private immediately on new discussions so the first INSERT writes
+        // is_private=1, closing the race window where the discussion is briefly
+        // visible to non-recipients (issue #239).
+        //
+        // Also pre-populate the relation cache on this $discussion object so all
+        // subsequent saves on the same stale instance (e.g. the final save in
+        // StartDiscussionHandler) also see non-empty recipients and keep is_private=1
+        // rather than resetting it to 0.
+        if (!$event->discussion->exists && $this->screener->isPrivate()) {
+            $event->discussion->is_private = true;
+            $event->discussion->setRelation('recipientUsers', $this->screener->users);
+            $event->discussion->setRelation('recipientGroups', $this->screener->groups);
         }
 
         // When discussions need approval and this is a private disucussion, ignore approvals.

--- a/src/Listeners/PersistRecipients.php
+++ b/src/Listeners/PersistRecipients.php
@@ -60,7 +60,7 @@ class PersistRecipients
             return null;
         }
 
-        if ($event->actor->cannot('startPrivateDiscussionWithBlockers') && $this->screener->hasBlockingUsers()) {
+        if ($event->actor->cannot('discussion.startPrivateDiscussionWithBlockers') && $this->screener->hasBlockingUsers()) {
             throw new PermissionDeniedException('Not allowed to add users that blocked receiving private discussions');
         }
 
@@ -75,6 +75,29 @@ class PersistRecipients
         if (!$event->discussion->exists) {
             $this->checkPermissionsForNewDiscussion($event->actor);
             $event->discussion->isByobu = true;
+
+            // Set is_private immediately so the first INSERT writes is_private=1,
+            // closing the race window where the discussion is briefly visible to
+            // non-recipients (issue #239).
+            //
+            // Also pre-populate the relation cache on this $discussion object so
+            // all subsequent saves on the same stale instance (e.g. the final save
+            // in StartDiscussionHandler) also see non-empty recipients and keep
+            // is_private=1 rather than resetting it to 0.
+            //
+            // Ensure the actor is always included as a user recipient (issue #168).
+            // This is required both so they can read their own discussion and so that
+            // core's PostReplyHandler can find the discussion via scoped visibility
+            // between the INSERT and the afterSave that writes recipient rows.
+            if ($this->screener->isPrivate()) {
+                if (!$this->screener->users->contains($event->actor)) {
+                    $this->screener->users = $this->screener->users->concat([$event->actor]);
+                }
+
+                $event->discussion->is_private = true;
+                $event->discussion->setRelation('recipientUsers', $this->screener->users);
+                $event->discussion->setRelation('recipientGroups', $this->screener->groups);
+            }
         } else {
             $this->checkPermissionsForExistingDiscussion($event->actor, $event->discussion);
         }

--- a/tests/integration/api/AbstractCreatePrivateDiscussionTest.php
+++ b/tests/integration/api/AbstractCreatePrivateDiscussionTest.php
@@ -77,9 +77,9 @@ abstract class AbstractCreatePrivateDiscussionTest extends TestCase
         $response = $this->send(
             $this->request('POST', '/api/discussions', [
                 'authenticatedAs' => $actorId,
-                'json' => [
+                'json'            => [
                     'data' => [
-                        'type' => 'discussions',
+                        'type'       => 'discussions',
                         'attributes' => array_merge([
                             'title'   => 'Private discussion',
                             'content' => 'Secret content.',
@@ -208,7 +208,7 @@ abstract class AbstractCreatePrivateDiscussionTest extends TestCase
         $this->assertEquals(200, $this->getDiscussion($discussionId, 2), 'Actor (id=2) cannot read own private discussion.');
         $this->assertEquals(200, $this->getDiscussion($discussionId, 3), 'Recipient alice (id=3) cannot read the private discussion.');
         $this->assertEquals(404, $this->getDiscussion($discussionId, 5), 'Outsider (id=5) can read the private discussion.');
-        $this->assertEquals(404, $this->getDiscussion($discussionId),    'Guest can read the private discussion.');
+        $this->assertEquals(404, $this->getDiscussion($discussionId), 'Guest can read the private discussion.');
     }
 
     // -------------------------------------------------------------------------
@@ -231,7 +231,7 @@ abstract class AbstractCreatePrivateDiscussionTest extends TestCase
         $this->assertEquals(200, $this->getDiscussion($discussionId, 3), 'alice (id=3, Staff member) cannot read the group-private discussion.');
         $this->assertEquals(200, $this->getDiscussion($discussionId, 4), 'bob (id=4, Staff member) cannot read the group-private discussion.');
         $this->assertEquals(404, $this->getDiscussion($discussionId, 5), 'Outsider (id=5) can read the group-private discussion.');
-        $this->assertEquals(404, $this->getDiscussion($discussionId),    'Guest can read the group-private discussion.');
+        $this->assertEquals(404, $this->getDiscussion($discussionId), 'Guest can read the group-private discussion.');
     }
 
     // -------------------------------------------------------------------------
@@ -258,7 +258,7 @@ abstract class AbstractCreatePrivateDiscussionTest extends TestCase
         $this->assertEquals(200, $this->getDiscussion($discussionId, 3), 'alice (id=3) cannot read the discussion (via group).');
         $this->assertEquals(200, $this->getDiscussion($discussionId, 4), 'bob (id=4) cannot read the discussion (via group).');
         $this->assertEquals(404, $this->getDiscussion($discussionId, 5), 'Outsider (id=5) can read the discussion.');
-        $this->assertEquals(404, $this->getDiscussion($discussionId),    'Guest can read the discussion.');
+        $this->assertEquals(404, $this->getDiscussion($discussionId), 'Guest can read the discussion.');
     }
 
     // -------------------------------------------------------------------------

--- a/tests/integration/api/AbstractCreatePrivateDiscussionTest.php
+++ b/tests/integration/api/AbstractCreatePrivateDiscussionTest.php
@@ -1,0 +1,355 @@
+<?php
+
+/*
+ * This file is part of fof/byobu.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FoF\Byobu\Tests\integration\api;
+
+use Flarum\Group\Group;
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\Testing\integration\TestCase;
+
+/**
+ * Shared test logic for creating private discussions.
+ *
+ * Subclasses boot the app with or without flarum/tags to confirm that byobu
+ * behaves identically in both configurations. Tags-specific assertions live
+ * only in {@see CreatePrivateDiscussionWithTagsTest}.
+ *
+ * Permissions are NOT granted in setUp. Each test that needs a permission
+ * calls grantPermission() explicitly, keeping "no permission → 403" tests clean.
+ */
+abstract class AbstractCreatePrivateDiscussionTest extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->extension('fof-byobu');
+
+        $this->prepareDatabase([
+            'users' => [
+                // id=1: admin (seeded by Flarum TestCase)
+                $this->normalUser(),                                      // id=2: plain member, no byobu perms by default
+                ['id' => 3, 'username' => 'alice',    'email' => 'alice@example.com',    'password' => 'too-obscure', 'is_email_confirmed' => 1],
+                ['id' => 4, 'username' => 'bob',      'email' => 'bob@example.com',      'password' => 'too-obscure', 'is_email_confirmed' => 1],
+                ['id' => 5, 'username' => 'outsider', 'email' => 'outsider@example.com', 'password' => 'too-obscure', 'is_email_confirmed' => 1],
+                ['id' => 6, 'username' => 'blocker',  'email' => 'blocker@example.com',  'password' => 'too-obscure', 'is_email_confirmed' => 1, 'blocks_byobu_pd' => 1],
+            ],
+            'groups' => [
+                // Groups 1–4 are seeded by Flarum (admin/guest/member/mod). Add a custom group.
+                ['id' => 10, 'name_singular' => 'Staff', 'name_plural' => 'Staff', 'color' => null, 'icon' => null, 'is_hidden' => 0],
+            ],
+            'group_user' => [
+                // alice (3) and bob (4) are in Staff (10); outsider (5) is not.
+                ['user_id' => 3, 'group_id' => 10],
+                ['user_id' => 4, 'group_id' => 10],
+            ],
+        ]);
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    protected function grantPermission(string $permission, int $groupId = Group::MEMBER_ID): void
+    {
+        $this->prepareDatabase([
+            'group_permission' => [
+                ['group_id' => $groupId, 'permission' => $permission],
+            ],
+        ]);
+    }
+
+    /**
+     * POST /api/discussions. Returns ['status' => int, 'body' => array].
+     */
+    protected function postDiscussion(int $actorId, array $relationships = [], array $extraAttributes = []): array
+    {
+        $response = $this->send(
+            $this->request('POST', '/api/discussions', [
+                'authenticatedAs' => $actorId,
+                'json' => [
+                    'data' => [
+                        'type' => 'discussions',
+                        'attributes' => array_merge([
+                            'title'   => 'Private discussion',
+                            'content' => 'Secret content.',
+                        ], $extraAttributes),
+                        'relationships' => $relationships,
+                    ],
+                ],
+            ])
+        );
+
+        return [
+            'status' => $response->getStatusCode(),
+            'body'   => json_decode($response->getBody()->getContents(), true),
+        ];
+    }
+
+    protected function getDiscussion(int $discussionId, ?int $actorId = null): int
+    {
+        return $this->send(
+            $this->request('GET', "/api/discussions/$discussionId", array_filter([
+                'authenticatedAs' => $actorId,
+            ]))
+        )->getStatusCode();
+    }
+
+    protected function userRecipients(int ...$ids): array
+    {
+        return [
+            'recipientUsers' => [
+                'data' => array_map(fn ($id) => ['type' => 'users', 'id' => (string) $id], $ids),
+            ],
+        ];
+    }
+
+    protected function groupRecipients(int ...$ids): array
+    {
+        return [
+            'recipientGroups' => [
+                'data' => array_map(fn ($id) => ['type' => 'groups', 'id' => (string) $id], $ids),
+            ],
+        ];
+    }
+
+    // -------------------------------------------------------------------------
+    // Permission: user recipients
+    // -------------------------------------------------------------------------
+
+    /**
+     * @test
+     */
+    public function member_with_user_permission_can_create_private_discussion_with_users()
+    {
+        $this->grantPermission('discussion.startPrivateDiscussionWithUsers');
+
+        $result = $this->postDiscussion(2, $this->userRecipients(2, 3));
+
+        $this->assertEquals(201, $result['status']);
+    }
+
+    /**
+     * @test
+     */
+    public function member_without_user_permission_cannot_create_private_discussion_with_users()
+    {
+        $result = $this->postDiscussion(2, $this->userRecipients(2, 3));
+
+        $this->assertEquals(403, $result['status']);
+    }
+
+    // -------------------------------------------------------------------------
+    // Permission: group recipients
+    // -------------------------------------------------------------------------
+
+    /**
+     * @test
+     */
+    public function member_with_group_permission_can_create_private_discussion_with_groups()
+    {
+        $this->grantPermission('discussion.startPrivateDiscussionWithGroups');
+
+        $result = $this->postDiscussion(2, $this->groupRecipients(10));
+
+        $this->assertEquals(201, $result['status']);
+    }
+
+    /**
+     * @test
+     */
+    public function member_without_group_permission_cannot_create_private_discussion_with_groups()
+    {
+        $result = $this->postDiscussion(2, $this->groupRecipients(10));
+
+        $this->assertEquals(403, $result['status']);
+    }
+
+    /**
+     * @test
+     *
+     * Having the user permission does not grant the group permission.
+     */
+    public function member_with_only_user_permission_cannot_create_private_discussion_with_groups()
+    {
+        $this->grantPermission('discussion.startPrivateDiscussionWithUsers');
+
+        $result = $this->postDiscussion(2, $this->groupRecipients(10));
+
+        $this->assertEquals(403, $result['status']);
+    }
+
+    // -------------------------------------------------------------------------
+    // Visibility: user recipients
+    // -------------------------------------------------------------------------
+
+    /**
+     * @test
+     */
+    public function private_discussion_with_users_is_visible_to_recipients_only()
+    {
+        $this->grantPermission('discussion.startPrivateDiscussionWithUsers');
+
+        $result = $this->postDiscussion(2, $this->userRecipients(2, 3));
+        $this->assertEquals(201, $result['status'], json_encode($result['body']));
+
+        $discussionId = $result['body']['data']['id'];
+
+        $this->assertEquals(200, $this->getDiscussion($discussionId, 2), 'Actor (id=2) cannot read own private discussion.');
+        $this->assertEquals(200, $this->getDiscussion($discussionId, 3), 'Recipient alice (id=3) cannot read the private discussion.');
+        $this->assertEquals(404, $this->getDiscussion($discussionId, 5), 'Outsider (id=5) can read the private discussion.');
+        $this->assertEquals(404, $this->getDiscussion($discussionId),    'Guest can read the private discussion.');
+    }
+
+    // -------------------------------------------------------------------------
+    // Visibility: group recipients
+    // -------------------------------------------------------------------------
+
+    /**
+     * @test
+     */
+    public function private_discussion_with_group_is_visible_to_group_members_only()
+    {
+        $this->grantPermission('discussion.startPrivateDiscussionWithGroups');
+
+        // Actor (2) sends to Staff group (10). alice (3) and bob (4) are members; outsider (5) is not.
+        $result = $this->postDiscussion(2, $this->groupRecipients(10));
+        $this->assertEquals(201, $result['status'], json_encode($result['body']));
+
+        $discussionId = $result['body']['data']['id'];
+
+        $this->assertEquals(200, $this->getDiscussion($discussionId, 3), 'alice (id=3, Staff member) cannot read the group-private discussion.');
+        $this->assertEquals(200, $this->getDiscussion($discussionId, 4), 'bob (id=4, Staff member) cannot read the group-private discussion.');
+        $this->assertEquals(404, $this->getDiscussion($discussionId, 5), 'Outsider (id=5) can read the group-private discussion.');
+        $this->assertEquals(404, $this->getDiscussion($discussionId),    'Guest can read the group-private discussion.');
+    }
+
+    // -------------------------------------------------------------------------
+    // Visibility: mixed user + group recipients
+    // -------------------------------------------------------------------------
+
+    /**
+     * @test
+     */
+    public function private_discussion_with_users_and_groups_is_visible_to_all_recipients()
+    {
+        $this->grantPermission('discussion.startPrivateDiscussionWithUsers');
+        $this->grantPermission('discussion.startPrivateDiscussionWithGroups');
+
+        $result = $this->postDiscussion(2, array_merge(
+            $this->userRecipients(2),
+            $this->groupRecipients(10)
+        ));
+        $this->assertEquals(201, $result['status'], json_encode($result['body']));
+
+        $discussionId = $result['body']['data']['id'];
+
+        $this->assertEquals(200, $this->getDiscussion($discussionId, 2), 'Actor (id=2) cannot read own private discussion.');
+        $this->assertEquals(200, $this->getDiscussion($discussionId, 3), 'alice (id=3) cannot read the discussion (via group).');
+        $this->assertEquals(200, $this->getDiscussion($discussionId, 4), 'bob (id=4) cannot read the discussion (via group).');
+        $this->assertEquals(404, $this->getDiscussion($discussionId, 5), 'Outsider (id=5) can read the discussion.');
+        $this->assertEquals(404, $this->getDiscussion($discussionId),    'Guest can read the discussion.');
+    }
+
+    // -------------------------------------------------------------------------
+    // blocks_byobu_pd
+    // -------------------------------------------------------------------------
+
+    /**
+     * @test
+     */
+    public function cannot_add_user_who_has_blocked_private_discussions()
+    {
+        $this->grantPermission('discussion.startPrivateDiscussionWithUsers');
+
+        $result = $this->postDiscussion(2, $this->userRecipients(2, 6));
+
+        $this->assertEquals(403, $result['status']);
+    }
+
+    /**
+     * @test
+     */
+    public function can_add_blocking_user_when_actor_has_override_permission()
+    {
+        $this->grantPermission('discussion.startPrivateDiscussionWithUsers');
+        $this->grantPermission('discussion.startPrivateDiscussionWithBlockers');
+
+        $result = $this->postDiscussion(2, $this->userRecipients(2, 6));
+
+        $this->assertEquals(201, $result['status']);
+    }
+
+    /**
+     * @test
+     */
+    public function actor_who_has_blocked_private_discussions_can_still_create_one()
+    {
+        $this->grantPermission('discussion.startPrivateDiscussionWithUsers');
+
+        $this->prepareDatabase([
+            'users' => [
+                ['id' => 2, 'username' => 'normal', 'email' => 'normal@machine.local', 'password' => 'too-obscure', 'is_email_confirmed' => 1, 'blocks_byobu_pd' => 1],
+            ],
+        ]);
+
+        $result = $this->postDiscussion(2, $this->userRecipients(2, 3));
+
+        $this->assertEquals(201, $result['status']);
+    }
+
+    // -------------------------------------------------------------------------
+    // Issue #168: actor excluded from own recipients
+    // -------------------------------------------------------------------------
+
+    /**
+     * @test
+     *
+     * Reproduces issue #168: a user creates a private discussion without including
+     * themselves in the recipient list. The creator must always be auto-added as a
+     * recipient so they can read what they created.
+     */
+    public function creator_is_always_a_recipient_of_their_own_private_discussion()
+    {
+        $this->grantPermission('discussion.startPrivateDiscussionWithUsers');
+
+        // Actor (2) deliberately omits themselves — only alice (3) is in the payload.
+        $result = $this->postDiscussion(2, $this->userRecipients(3));
+        $this->assertEquals(201, $result['status'], json_encode($result['body']));
+
+        $discussionId = $result['body']['data']['id'];
+
+        $this->assertEquals(200, $this->getDiscussion($discussionId, 2), 'Creator (id=2) is locked out of their own private discussion (issue #168).');
+        $this->assertEquals(200, $this->getDiscussion($discussionId, 3), 'alice (id=3) cannot read the private discussion.');
+        $this->assertEquals(404, $this->getDiscussion($discussionId, 5), 'Outsider (id=5) can read the private discussion.');
+    }
+
+    /**
+     * @test
+     *
+     * Variant of issue #168 with group recipients: actor sends to a group they are
+     * not a member of and omits themselves from the user recipient list.
+     */
+    public function creator_is_always_a_recipient_when_sending_to_group_they_are_not_in()
+    {
+        $this->grantPermission('discussion.startPrivateDiscussionWithGroups');
+
+        // Actor (2) is not in Staff group (10). They send only to the group.
+        $result = $this->postDiscussion(2, $this->groupRecipients(10));
+        $this->assertEquals(201, $result['status'], json_encode($result['body']));
+
+        $discussionId = $result['body']['data']['id'];
+
+        $this->assertEquals(200, $this->getDiscussion($discussionId, 2), 'Creator (id=2) is locked out of a group-private discussion they started (issue #168).');
+    }
+}

--- a/tests/integration/api/CreatePrivateDiscussionTest.php
+++ b/tests/integration/api/CreatePrivateDiscussionTest.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of fof/byobu.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FoF\Byobu\Tests\integration\api;
+
+/**
+ * Runs all private discussion creation tests without flarum/tags active.
+ */
+class CreatePrivateDiscussionTest extends AbstractCreatePrivateDiscussionTest
+{
+    // All shared tests are inherited from AbstractCreatePrivateDiscussionTest.
+    // No tags extension is loaded, so tag-related behaviour is not exercised here.
+}

--- a/tests/integration/api/CreatePrivateDiscussionWithTagsTest.php
+++ b/tests/integration/api/CreatePrivateDiscussionWithTagsTest.php
@@ -1,0 +1,83 @@
+<?php
+
+/*
+ * This file is part of fof/byobu.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FoF\Byobu\Tests\integration\api;
+
+/**
+ * Runs all private discussion creation tests with flarum/tags active, plus
+ * tags-specific assertions that only apply when that extension is present.
+ */
+class CreatePrivateDiscussionWithTagsTest extends AbstractCreatePrivateDiscussionTest
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->extension('flarum-tags');
+
+        $this->prepareDatabase([
+            'tags' => [
+                ['id' => 1, 'name' => 'General', 'slug' => 'general', 'color' => '#888', 'position' => 0, 'is_restricted' => 0],
+            ],
+        ]);
+    }
+
+    // -------------------------------------------------------------------------
+    // Tags-specific tests
+    // -------------------------------------------------------------------------
+
+    /**
+     * @test
+     *
+     * Private discussions bypass the tag requirement, so creation succeeds even
+     * when no tag is supplied despite flarum/tags being active.
+     */
+    public function private_discussion_can_be_created_without_a_tag_when_tags_enabled()
+    {
+        $this->grantPermission('discussion.startPrivateDiscussionWithUsers');
+
+        $result = $this->postDiscussion(2, $this->userRecipients(2, 3));
+
+        $this->assertEquals(201, $result['status']);
+    }
+
+    /**
+     * @test
+     *
+     * If a tag is supplied in the creation payload for a private discussion,
+     * DropTagsOnPrivateDiscussions silently strips it — creation still succeeds
+     * but no tag is associated with the discussion.
+     */
+    public function tags_supplied_with_private_discussion_payload_are_silently_dropped()
+    {
+        $this->grantPermission('discussion.startPrivateDiscussionWithUsers');
+
+        $relationships = array_merge(
+            $this->userRecipients(2, 3),
+            ['tags' => ['data' => [['type' => 'tags', 'id' => '1']]]]
+        );
+
+        $result = $this->postDiscussion(2, $relationships);
+        $this->assertEquals(201, $result['status'], json_encode($result['body']));
+
+        $discussionId = $result['body']['data']['id'];
+
+        $response = $this->send(
+            $this->request('GET', "/api/discussions/$discussionId?include=tags", [
+                'authenticatedAs' => 2,
+            ])
+        );
+        $body = json_decode($response->getBody()->getContents(), true);
+
+        $tagRelationship = $body['data']['relationships']['tags']['data'] ?? null;
+        $this->assertEmpty($tagRelationship, 'Discussion has tags attached despite being private.');
+    }
+}


### PR DESCRIPTION
## Summary

- **#239** — `is_private=0` race window on creation: `PersistRecipients` now sets `is_private=true` and pre-populates the relation cache before the first INSERT, preventing stale-object saves from resetting it back to `0`
- **#168** — Creator excluded from own recipients: actor is always injected into the recipient collection on creation, ensuring they can read their own discussion and unblocking `PostReplyHandler`'s scoped visibility lookup
- **Permission string mismatch** — `startPrivateDiscussionWithBlockers` was checked without the `discussion.` prefix in both `PersistRecipients` and `AllowsPdGambit`, so the override permission never functioned
- **`Arr::exists` → `Arr::has`** in `DropTagsOnPrivateDiscussions` — `Arr::exists` does not support dot-notation paths, so tags were never stripped from private discussion creation payloads

## Tests

Integration tests added covering all four fixes, run in two configurations via an abstract base class:
- `CreatePrivateDiscussionTest` — without `flarum/tags`
- `CreatePrivateDiscussionWithTagsTest` — with `flarum/tags`, plus tags-specific assertions

32 tests, all passing.