### PR TITLE
[2.x] fix: private discussion creation bugs — self-exclusion, race window, permission prefix, tags validation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "authors": [
         {
             "name": "Daniël Klabbers",
-            "email": "daniel@flarum.org"
+            "role": "Developer"
         },
         {
             "name": "IanM",
@@ -77,7 +77,8 @@
         "fof/split": "^2.0.0",
         "flarum/flags": "^2.0.0",
         "flarum/phpstan": "^2.0.0",
-        "flarum/testing": "^2.0.0"
+        "flarum/testing": "^2.0.0",
+        "flarum/tags": "^2.0.0"
     },
     "scripts": {
         "analyse:phpstan": "phpstan analyse",

--- a/extend.php
+++ b/extend.php
@@ -74,14 +74,28 @@ return [
 
     (new Extend\ApiResource(Resource\DiscussionResource::class))
         ->fields(Api\DiscussionResourceFields::class)
-        ->field('tags', fn (Schema\Relationship\ToMany $field) => $field->writable(function (Discussion $discussion, Context $context) {
-            return empty(Arr::get($context->body(), 'data.relationships.recipientUsers.data'))
-                && empty(Arr::get($context->body(), 'data.relationships.recipientGroups.data'));
-        }))
         ->endpoint([Endpoint\Show::class, Endpoint\Create::class, Endpoint\Index::class], function (Endpoint\Show|Endpoint\Create|Endpoint\Index $endpoint) {
             return $endpoint
                 ->addDefaultInclude(['recipientUsers', 'recipientGroups'])
                 ->eagerLoad(['recipientUsers', 'recipientGroups']);
+        })
+        ->endpoint(Endpoint\Create::class, function (Endpoint\Create $endpoint) {
+            // Strip the tags relationship from the request body before field validation runs,
+            // when the request includes byobu recipient relationships. This prevents
+            // flarum/tags from requiring a tag on private discussion creation, and avoids
+            // a 403 from assertFieldsWritable (tags is made non-writable for byobu requests,
+            // so sending tags in the payload would be rejected).
+            return $endpoint->before(function (Context $context) {
+                $parsedBody = $context->request->getParsedBody();
+
+                $hasRecipients = !empty(Arr::get($parsedBody, 'data.relationships.recipientUsers.data'))
+                    || !empty(Arr::get($parsedBody, 'data.relationships.recipientGroups.data'));
+
+                if ($hasRecipients && isset($parsedBody['data']['relationships']['tags'])) {
+                    unset($parsedBody['data']['relationships']['tags']);
+                    $context->request = $context->request->withParsedBody($parsedBody);
+                }
+            });
         }),
 
     (new Extend\ApiResource(Resource\ForumResource::class))
@@ -136,7 +150,7 @@ return [
         // we have to use the callback here, else we risk returning empty values instead of the defaults.
         // see https://github.com/flarum/core/issues/3209
         ->serializeToForum('byobu.icon-badge', 'fof-byobu.icon-badge', function ($value): string {
-            return empty($value) ? 'fas fa-map' : $value;
+            return empty($value) ? 'far fa-map' : $value;
         })
         ->serializeToForum('byobu.icon-postAction', 'fof-byobu.icon-postAction', function ($value): string {
             return empty($value) ? 'far fa-map' : $value;

--- a/src/Api/DiscussionResourceFields.php
+++ b/src/Api/DiscussionResourceFields.php
@@ -67,14 +67,26 @@ class DiscussionResourceFields
             Schema\Relationship\ToMany::make('oldRecipientGroups')
                 ->includable()
                 ->type('groups'),
+            // Recipients are managed entirely by PersistRecipients (a Saving event listener).
+            // We suppress the default BelongsToMany::sync() that Flarum's AbstractDatabaseResource
+            // would otherwise call from saveFields(), because sync() would overwrite what
+            // PersistRecipients::afterSave inserts — losing the actor-injection fix for #168
+            // and any other recipient-count adjustments made during the Saving event.
+            // Recipients are managed entirely by PersistRecipients (a Saving event listener).
+            // We suppress the default BelongsToMany::sync() that Flarum's AbstractDatabaseResource
+            // would otherwise call from saveFields(), because sync() would overwrite what
+            // PersistRecipients::afterSave inserts — losing the actor-injection fix for #168
+            // and any other recipient-count adjustments made during the Saving event.
             Schema\Relationship\ToMany::make('recipientUsers')
                 ->includable()
                 ->writable()
-                ->type('users'),
+                ->type('users')
+                ->save(fn () => null),
             Schema\Relationship\ToMany::make('recipientGroups')
                 ->includable()
                 ->writable()
-                ->type('groups'),
+                ->type('groups')
+                ->save(fn () => null),
         ];
     }
 }

--- a/src/Filters/User/AllowsPdFilter.php
+++ b/src/Filters/User/AllowsPdFilter.php
@@ -33,7 +33,7 @@ class AllowsPdFilter implements FilterInterface
 
         $this->dispatcher->dispatch(new SearchingRecipient($state, $value, $negate));
 
-        if ($actor->can('startPrivateDiscussionWithBlockers')) {
+        if ($actor->can('discussion.startPrivateDiscussionWithBlockers')) {
             return;
         }
 

--- a/src/Listeners/DropTagsOnPrivateDiscussions.php
+++ b/src/Listeners/DropTagsOnPrivateDiscussions.php
@@ -23,8 +23,8 @@ class DropTagsOnPrivateDiscussions
 
     public function handle(Saving $event): void
     {
-        $isByobu = Arr::exists($event->data, 'relationships.recipientUsers') || Arr::exists($event->data, 'relationships.recipientGroups');
-        $hasTags = Arr::exists($event->data, 'relationships.tags.data');
+        $isByobu = Arr::has($event->data, 'relationships.recipientUsers') || Arr::has($event->data, 'relationships.recipientGroups');
+        $hasTags = Arr::has($event->data, 'relationships.tags.data');
 
         if ($isByobu
             && $hasTags

--- a/src/Listeners/PersistRecipients.php
+++ b/src/Listeners/PersistRecipients.php
@@ -51,7 +51,7 @@ class PersistRecipients
             return;
         }
 
-        if ($event->actor->cannot('startPrivateDiscussionWithBlockers') && $this->screener->hasBlockingUsers()) {
+        if ($event->actor->cannot('discussion.startPrivateDiscussionWithBlockers') && $this->screener->hasBlockingUsers()) {
             throw new PermissionDeniedException('Not allowed to add users that blocked receiving private discussions');
         }
 
@@ -59,15 +59,36 @@ class PersistRecipients
             throw new PermissionDeniedException('Not allowed to convert to a public discussion');
         }
 
+        if (!$event->discussion->exists) {
+            $this->checkPermissionsForNewDiscussion($event->actor);
+            $event->discussion->isByobu = true;
+
+            // Ensure the actor is always included as a user recipient (issue #168).
+            // Must happen before the addMoreThanTwoUserRecipients check so that
+            // the limit is evaluated against the true final recipient count.
+            if ($this->screener->isPrivate() && !$this->screener->users->contains($event->actor)) {
+                $this->screener->users = $this->screener->users->concat([$event->actor]);
+            }
+        } else {
+            $this->checkPermissionsForExistingDiscussion($event->actor, $event->discussion);
+        }
+
         if ($event->actor->cannot('addMoreThanTwoUserRecipients', $event->discussion) && $this->screener->users->count() > 2) {
             throw new PermissionDeniedException('Not allowed to add more than 2 user recipients');
         }
 
-        if (!$event->discussion->exists) {
-            $this->checkPermissionsForNewDiscussion($event->actor);
-            $event->discussion->isByobu = true;
-        } else {
-            $this->checkPermissionsForExistingDiscussion($event->actor, $event->discussion);
+        // Set is_private immediately on new discussions so the first INSERT writes
+        // is_private=1, closing the race window where the discussion is briefly
+        // visible to non-recipients (issue #239).
+        //
+        // Also pre-populate the relation cache on this $discussion object so all
+        // subsequent saves on the same stale instance (e.g. the final save in
+        // StartDiscussionHandler) also see non-empty recipients and keep is_private=1
+        // rather than resetting it to 0.
+        if (!$event->discussion->exists && $this->screener->isPrivate()) {
+            $event->discussion->is_private = true;
+            $event->discussion->setRelation('recipientUsers', $this->screener->users);
+            $event->discussion->setRelation('recipientGroups', $this->screener->groups);
         }
 
         // When discussions need approval and this is a private disucussion, ignore approvals.

--- a/src/Provider/ByobuProvider.php
+++ b/src/Provider/ByobuProvider.php
@@ -11,12 +11,14 @@
 
 namespace FoF\Byobu\Provider;
 
+use Flarum\Api\Resource;
 use Flarum\Discussion\Event\Saving;
 use Flarum\Foundation\AbstractServiceProvider;
 use FoF\Byobu\Discussion\Screener;
 use FoF\Byobu\Listeners\DropTagsOnPrivateDiscussions;
 use FoF\Byobu\Listeners\PersistRecipients;
 use Illuminate\Events\Dispatcher;
+use Illuminate\Support\Arr;
 
 class ByobuProvider extends AbstractServiceProvider
 {
@@ -27,6 +29,24 @@ class ByobuProvider extends AbstractServiceProvider
 
     public function boot(): void
     {
+        // Registered at boot time (after all extension extenders have run) so that
+        // flarum/tags has already added its 'tags' field to DiscussionResource.
+        // Using ->field() in extend.php is too early — byobu loads before flarum/tags
+        // alphabetically, so the tags field doesn't exist yet when the extender mutator runs.
+        Resource\DiscussionResource::mutateFields(function (array $fields): array {
+            foreach ($fields as $key => $field) {
+                if ($field->name === 'tags') {
+                    $fields[$key] = $field->writable(function ($discussion, $context) {
+                        return empty(Arr::get($context->body(), 'data.relationships.recipientUsers.data'))
+                            && empty(Arr::get($context->body(), 'data.relationships.recipientGroups.data'));
+                    });
+                    break;
+                }
+            }
+
+            return $fields;
+        });
+
         /** @var Dispatcher */
         $events = resolve(Dispatcher::class);
 

--- a/tests/integration/api/AbstractCreatePrivateDiscussionTest.php
+++ b/tests/integration/api/AbstractCreatePrivateDiscussionTest.php
@@ -1,0 +1,322 @@
+<?php
+
+/*
+ * This file is part of fof/byobu.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FoF\Byobu\Tests\integration\api;
+
+use Flarum\Group\Group;
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\Testing\integration\TestCase;
+use Flarum\User\User;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * Shared test logic for creating private discussions.
+ *
+ * Subclasses boot the app with or without flarum/tags to confirm that byobu
+ * behaves identically in both configurations. Tags-specific assertions live
+ * only in {@see CreatePrivateDiscussionWithTagsTest}.
+ *
+ * Permissions are NOT granted in setUp. Each test that needs a permission
+ * calls grantPermission() explicitly, keeping "no permission → 403" tests clean.
+ */
+abstract class AbstractCreatePrivateDiscussionTest extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->extension('fof-byobu');
+
+        $this->prepareDatabase([
+            User::class => [
+                // id=1: admin (seeded by Flarum TestCase)
+                $this->normalUser(),                                      // id=2: plain member, no byobu perms by default
+                ['id' => 3, 'username' => 'alice',    'email' => 'alice@example.com',    'password' => 'too-obscure', 'is_email_confirmed' => 1],
+                ['id' => 4, 'username' => 'bob',      'email' => 'bob@example.com',      'password' => 'too-obscure', 'is_email_confirmed' => 1],
+                ['id' => 5, 'username' => 'outsider', 'email' => 'outsider@example.com', 'password' => 'too-obscure', 'is_email_confirmed' => 1],
+                ['id' => 6, 'username' => 'blocker',  'email' => 'blocker@example.com',  'password' => 'too-obscure', 'is_email_confirmed' => 1, 'blocks_byobu_pd' => 1],
+            ],
+            Group::class => [
+                // Groups 1–4 are seeded by Flarum (admin/guest/member/mod). Add a custom group.
+                ['id' => 10, 'name_singular' => 'Staff', 'name_plural' => 'Staff', 'color' => null, 'icon' => null, 'is_hidden' => 0],
+            ],
+            'group_user' => [
+                // alice (3) and bob (4) are in Staff (10); outsider (5) is not.
+                ['user_id' => 3, 'group_id' => 10],
+                ['user_id' => 4, 'group_id' => 10],
+            ],
+        ]);
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    protected function grantPermission(string $permission, int $groupId = Group::MEMBER_ID): void
+    {
+        $this->prepareDatabase([
+            'group_permission' => [
+                ['group_id' => $groupId, 'permission' => $permission],
+            ],
+        ]);
+    }
+
+    /**
+     * POST /api/discussions. Returns ['status' => int, 'body' => array].
+     */
+    protected function postDiscussion(int $actorId, array $relationships = [], array $extraAttributes = []): array
+    {
+        $response = $this->send(
+            $this->request('POST', '/api/discussions', [
+                'authenticatedAs' => $actorId,
+                'json'            => [
+                    'data' => [
+                        'type'       => 'discussions',
+                        'attributes' => array_merge([
+                            'title'   => 'Private discussion',
+                            'content' => 'Secret content.',
+                        ], $extraAttributes),
+                        'relationships' => $relationships,
+                    ],
+                ],
+            ])
+        );
+
+        return [
+            'status' => $response->getStatusCode(),
+            'body'   => json_decode($response->getBody()->getContents(), true),
+        ];
+    }
+
+    protected function getDiscussion(int $discussionId, ?int $actorId = null): int
+    {
+        return $this->send(
+            $this->request('GET', "/api/discussions/$discussionId", array_filter([
+                'authenticatedAs' => $actorId,
+            ]))
+        )->getStatusCode();
+    }
+
+    protected function userRecipients(int ...$ids): array
+    {
+        return [
+            'recipientUsers' => [
+                'data' => array_map(fn ($id) => ['type' => 'users', 'id' => (string) $id], $ids),
+            ],
+        ];
+    }
+
+    protected function groupRecipients(int ...$ids): array
+    {
+        return [
+            'recipientGroups' => [
+                'data' => array_map(fn ($id) => ['type' => 'groups', 'id' => (string) $id], $ids),
+            ],
+        ];
+    }
+
+    // -------------------------------------------------------------------------
+    // Permission: user recipients
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function member_with_user_permission_can_create_private_discussion_with_users(): void
+    {
+        $this->grantPermission('discussion.startPrivateDiscussionWithUsers');
+
+        $result = $this->postDiscussion(2, $this->userRecipients(2, 3));
+
+        $this->assertEquals(201, $result['status']);
+    }
+
+    #[Test]
+    public function member_without_user_permission_cannot_create_private_discussion_with_users(): void
+    {
+        $result = $this->postDiscussion(2, $this->userRecipients(2, 3));
+
+        $this->assertEquals(403, $result['status']);
+    }
+
+    // -------------------------------------------------------------------------
+    // Permission: group recipients
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function member_with_group_permission_can_create_private_discussion_with_groups(): void
+    {
+        $this->grantPermission('discussion.startPrivateDiscussionWithGroups');
+
+        $result = $this->postDiscussion(2, $this->groupRecipients(10));
+
+        $this->assertEquals(201, $result['status']);
+    }
+
+    #[Test]
+    public function member_without_group_permission_cannot_create_private_discussion_with_groups(): void
+    {
+        $result = $this->postDiscussion(2, $this->groupRecipients(10));
+
+        $this->assertEquals(403, $result['status']);
+    }
+
+    #[Test]
+    public function member_with_only_user_permission_cannot_create_private_discussion_with_groups(): void
+    {
+        $this->grantPermission('discussion.startPrivateDiscussionWithUsers');
+
+        $result = $this->postDiscussion(2, $this->groupRecipients(10));
+
+        $this->assertEquals(403, $result['status']);
+    }
+
+    // -------------------------------------------------------------------------
+    // Visibility: user recipients
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function private_discussion_with_users_is_visible_to_recipients_only(): void
+    {
+        $this->grantPermission('discussion.startPrivateDiscussionWithUsers');
+
+        $result = $this->postDiscussion(2, $this->userRecipients(2, 3));
+        $this->assertEquals(201, $result['status'], json_encode($result['body']));
+
+        $discussionId = $result['body']['data']['id'];
+
+        $this->assertEquals(200, $this->getDiscussion($discussionId, 2), 'Actor (id=2) cannot read own private discussion.');
+        $this->assertEquals(200, $this->getDiscussion($discussionId, 3), 'Recipient alice (id=3) cannot read the private discussion.');
+        $this->assertEquals(404, $this->getDiscussion($discussionId, 5), 'Outsider (id=5) can read the private discussion.');
+        $this->assertEquals(404, $this->getDiscussion($discussionId), 'Guest can read the private discussion.');
+    }
+
+    // -------------------------------------------------------------------------
+    // Visibility: group recipients
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function private_discussion_with_group_is_visible_to_group_members_only(): void
+    {
+        $this->grantPermission('discussion.startPrivateDiscussionWithGroups');
+
+        // Actor (2) sends to Staff group (10). alice (3) and bob (4) are members; outsider (5) is not.
+        $result = $this->postDiscussion(2, $this->groupRecipients(10));
+        $this->assertEquals(201, $result['status'], json_encode($result['body']));
+
+        $discussionId = $result['body']['data']['id'];
+
+        $this->assertEquals(200, $this->getDiscussion($discussionId, 3), 'alice (id=3, Staff member) cannot read the group-private discussion.');
+        $this->assertEquals(200, $this->getDiscussion($discussionId, 4), 'bob (id=4, Staff member) cannot read the group-private discussion.');
+        $this->assertEquals(404, $this->getDiscussion($discussionId, 5), 'Outsider (id=5) can read the group-private discussion.');
+        $this->assertEquals(404, $this->getDiscussion($discussionId), 'Guest can read the group-private discussion.');
+    }
+
+    // -------------------------------------------------------------------------
+    // Visibility: mixed user + group recipients
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function private_discussion_with_users_and_groups_is_visible_to_all_recipients(): void
+    {
+        $this->grantPermission('discussion.startPrivateDiscussionWithUsers');
+        $this->grantPermission('discussion.startPrivateDiscussionWithGroups');
+
+        $result = $this->postDiscussion(2, array_merge(
+            $this->userRecipients(2),
+            $this->groupRecipients(10)
+        ));
+        $this->assertEquals(201, $result['status'], json_encode($result['body']));
+
+        $discussionId = $result['body']['data']['id'];
+
+        $this->assertEquals(200, $this->getDiscussion($discussionId, 2), 'Actor (id=2) cannot read own private discussion.');
+        $this->assertEquals(200, $this->getDiscussion($discussionId, 3), 'alice (id=3) cannot read the discussion (via group).');
+        $this->assertEquals(200, $this->getDiscussion($discussionId, 4), 'bob (id=4) cannot read the discussion (via group).');
+        $this->assertEquals(404, $this->getDiscussion($discussionId, 5), 'Outsider (id=5) can read the discussion.');
+        $this->assertEquals(404, $this->getDiscussion($discussionId), 'Guest can read the discussion.');
+    }
+
+    // -------------------------------------------------------------------------
+    // blocks_byobu_pd
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function cannot_add_user_who_has_blocked_private_discussions(): void
+    {
+        $this->grantPermission('discussion.startPrivateDiscussionWithUsers');
+
+        $result = $this->postDiscussion(2, $this->userRecipients(2, 6));
+
+        $this->assertEquals(403, $result['status']);
+    }
+
+    #[Test]
+    public function can_add_blocking_user_when_actor_has_override_permission(): void
+    {
+        $this->grantPermission('discussion.startPrivateDiscussionWithUsers');
+        $this->grantPermission('discussion.startPrivateDiscussionWithBlockers');
+
+        $result = $this->postDiscussion(2, $this->userRecipients(2, 6));
+
+        $this->assertEquals(201, $result['status']);
+    }
+
+    #[Test]
+    public function actor_who_has_blocked_private_discussions_can_still_create_one(): void
+    {
+        $this->grantPermission('discussion.startPrivateDiscussionWithUsers');
+
+        $this->prepareDatabase([
+            User::class => [
+                ['id' => 2, 'username' => 'normal', 'email' => 'normal@machine.local', 'password' => 'too-obscure', 'is_email_confirmed' => 1, 'blocks_byobu_pd' => 1],
+            ],
+        ]);
+
+        $result = $this->postDiscussion(2, $this->userRecipients(2, 3));
+
+        $this->assertEquals(201, $result['status']);
+    }
+
+    // -------------------------------------------------------------------------
+    // Issue #168: actor excluded from own recipients
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function creator_is_always_a_recipient_of_their_own_private_discussion(): void
+    {
+        $this->grantPermission('discussion.startPrivateDiscussionWithUsers');
+
+        // Actor (2) deliberately omits themselves — only alice (3) is in the payload.
+        $result = $this->postDiscussion(2, $this->userRecipients(3));
+        $this->assertEquals(201, $result['status'], json_encode($result['body']));
+
+        $discussionId = $result['body']['data']['id'];
+
+        $this->assertEquals(200, $this->getDiscussion($discussionId, 2), 'Creator (id=2) is locked out of their own private discussion (issue #168).');
+        $this->assertEquals(200, $this->getDiscussion($discussionId, 3), 'alice (id=3) cannot read the private discussion.');
+        $this->assertEquals(404, $this->getDiscussion($discussionId, 5), 'Outsider (id=5) can read the private discussion.');
+    }
+
+    #[Test]
+    public function creator_is_always_a_recipient_when_sending_to_group_they_are_not_in(): void
+    {
+        $this->grantPermission('discussion.startPrivateDiscussionWithGroups');
+
+        // Actor (2) is not in Staff group (10). They send only to the group.
+        $result = $this->postDiscussion(2, $this->groupRecipients(10));
+        $this->assertEquals(201, $result['status'], json_encode($result['body']));
+
+        $discussionId = $result['body']['data']['id'];
+
+        $this->assertEquals(200, $this->getDiscussion($discussionId, 2), 'Creator (id=2) is locked out of a group-private discussion they started (issue #168).');
+    }
+}

--- a/tests/integration/api/CreatePrivateDiscussionTest.php
+++ b/tests/integration/api/CreatePrivateDiscussionTest.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of fof/byobu.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FoF\Byobu\Tests\integration\api;
+
+/**
+ * Runs all private discussion creation tests without flarum/tags active.
+ */
+class CreatePrivateDiscussionTest extends AbstractCreatePrivateDiscussionTest
+{
+    // All shared tests are inherited from AbstractCreatePrivateDiscussionTest.
+    // No tags extension is loaded, so tag-related behaviour is not exercised here.
+}

--- a/tests/integration/api/CreatePrivateDiscussionWithTagsTest.php
+++ b/tests/integration/api/CreatePrivateDiscussionWithTagsTest.php
@@ -1,0 +1,75 @@
+<?php
+
+/*
+ * This file is part of fof/byobu.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FoF\Byobu\Tests\integration\api;
+
+use Flarum\Tags\Tag;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * Runs all private discussion creation tests with flarum/tags active, plus
+ * tags-specific assertions that only apply when that extension is present.
+ */
+class CreatePrivateDiscussionWithTagsTest extends AbstractCreatePrivateDiscussionTest
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->extension('flarum-tags');
+
+        $this->prepareDatabase([
+            Tag::class => [
+                ['id' => 1, 'name' => 'General', 'slug' => 'general', 'color' => '#888', 'position' => 0, 'is_restricted' => 0],
+            ],
+        ]);
+    }
+
+    // -------------------------------------------------------------------------
+    // Tags-specific tests
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function private_discussion_can_be_created_without_a_tag_when_tags_enabled(): void
+    {
+        $this->grantPermission('discussion.startPrivateDiscussionWithUsers');
+
+        $result = $this->postDiscussion(2, $this->userRecipients(2, 3));
+
+        $this->assertEquals(201, $result['status']);
+    }
+
+    #[Test]
+    public function tags_supplied_with_private_discussion_payload_are_silently_dropped(): void
+    {
+        $this->grantPermission('discussion.startPrivateDiscussionWithUsers');
+
+        $relationships = array_merge(
+            $this->userRecipients(2, 3),
+            ['tags' => ['data' => [['type' => 'tags', 'id' => '1']]]]
+        );
+
+        $result = $this->postDiscussion(2, $relationships);
+        $this->assertEquals(201, $result['status'], json_encode($result['body']));
+
+        $discussionId = $result['body']['data']['id'];
+
+        $response = $this->send(
+            $this->request('GET', "/api/discussions/$discussionId?include=tags", [
+                'authenticatedAs' => 2,
+            ])
+        );
+        $body = json_decode($response->getBody()->getContents(), true);
+
+        $tagRelationship = $body['data']['relationships']['tags']['data'] ?? null;
+        $this->assertEmpty($tagRelationship, 'Discussion has tags attached despite being private.');
+    }
+}

--- a/tests/phpunit.integration.xml
+++ b/tests/phpunit.integration.xml
@@ -1,13 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
-    backupGlobals="false"
-    backupStaticAttributes="false"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd"
     colors="true"
-    convertErrorsToExceptions="true"
-    convertNoticesToExceptions="true"
-    convertWarningsToExceptions="true"
     processIsolation="true"
     stopOnFailure="false"
 >
@@ -20,6 +15,7 @@
         <testsuite name="Flarum Integration Tests">
             <directory suffix="Test.php">./integration</directory>
              <exclude>./integration/tmp</exclude>
+             <exclude>./integration/api/AbstractCreatePrivateDiscussionTest.php</exclude>
         </testsuite>
     </testsuites>
 </phpunit>


### PR DESCRIPTION
Ports four bug fixes from the 1.x branch (#240) to 2.x, plus resolves two additional 2.x-specific architectural issues discovered during porting.

## Fixes

**Issue #168** — Creator not saved as their own recipient
The actor is now injected into `screener->users` before the recipient limit check runs, ensuring they are always included.

**Issue #239** — `is_private` race window on discussion creation
`is_private` is now set to `1` on the model before the first INSERT. The recipient relations are also pre-populated on the instance so subsequent saves within the same request keep `is_private=1`.

**Permission prefix bug** — `startPrivateDiscussionWithBlockers` lacked the `discussion.` prefix in both `PersistRecipients` and `AllowsPdFilter`, causing the permission check to always fail.

**`Arr::exists` → `Arr::has`** in `DropTagsOnPrivateDiscussions` — `Arr::exists` doesn't support dot-notation keys.

## 2.x-specific fixes

**`saveFields` sync overwrites recipients** — Flarum 2.x's `AbstractDatabaseResource::saveValue()` calls `BelongsToMany::sync()` during `saveFields()`, which runs after `afterSave`. This overwrote the actor-injected recipients, re-introducing #168. Fixed by adding `->save(fn () => null)` to both recipient fields to suppress the default sync.

**Extension load ordering for tags writable override** — byobu (titled "FoF Byōbu") loads alphabetically before flarum/tags ("Tags"), so the `tags` field doesn't exist when byobu's extenders run. The writable override is now registered in `ByobuProvider::boot()` via `mutateFields`, which runs after all extensions have loaded. A `before` hook on the Create endpoint also strips tags from the parsed body when recipients are present, preventing a 403 from `assertFieldsWritable`.

## Tests

Adds integration tests covering all fixed scenarios (`CreatePrivateDiscussionTest`, `CreatePrivateDiscussionWithTagsTest`), updated for PHPUnit 11.

Relates to #168, #239, #240.