### PR TITLE
[1.x] chore(deps): add missing dependency on `flarum/tags`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,8 @@
     ],
     "require": {
         "php": "^8.0",
-        "flarum/core": "^1.8.6"
+        "flarum/core": "^1.8.6",
+        "flarum/tags": "*"
     },
     "extra": {
         "flarum-extension": {
@@ -51,7 +52,6 @@
             "optional-dependencies": [
                 "flarum/suspend",
                 "flarum/flags",
-                "flarum/tags",
                 "flarum/approval",
                 "v17development/flarum-support"
             ]


### PR DESCRIPTION
<!--
IMPORTANT: We LOVE seeing new pull requests, they excite us every single time they are submitted! As we have an obligation to maintain a healthy code standard, quality, and extensions, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #0000**
The JS crashes when flarum/tags is not enabled:
```
forum.js?v=da5c7e43:3356 Uncaught TypeError: Cannot read properties of undefined (reading 'prototype')
    at _inheritsLoose (forum.js?v=da5c7e43:3356:33)
    at extend.ts:21:49
    at ./src/forum/modals/ByobuTagDiscussionModal.js (extendDiscussionComposer.tsx:3:77)
```
This is due to this extension extending a class from `flarum/tags`:
https://github.com/FriendsOfFlarum/byobu/blob/4469e9af37d6e12e0ca5b6620ced2911ec1d89ee/js/src/forum/modals/ByobuTagDiscussionModal.js#L1-L16

**Changes proposed in this pull request:**
Make `flarum/tags` a hard dependency

**Reviewers should focus on:**
From past experiences such code patterns cannot simply be added in a conditional initializer / extension enabled check and require refactoring in implementation / mid term planning how we wanna approach this.

Follow up created at https://github.com/FriendsOfFlarum/byobu/issues/243.

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).

**Required changes:**

- [ ] Related [Flarum core extension PR's](https://github.com/flarum/core/pulls): (Omit this section if irrelevant)
