### PR TITLE
[1.x] fix: refresh discussion list when navigating to /private from non-IndexPage

### DIFF
--- a/js/src/forum/pages/PrivateDiscussionsPage.js
+++ b/js/src/forum/pages/PrivateDiscussionsPage.js
@@ -7,6 +7,13 @@ import PrivateComposing from './PrivateComposing';
 import PrivateHero from '../components/PrivateHero';
 
 export default function PrivateDiscussionsPage() {
+  extend(IndexPage.prototype, 'oninit', function () {
+    if (app.current.get('routeName') === 'byobuPrivate' && !app.previous.matches(IndexPage)) {
+      app.discussions.clear();
+      app.discussions.refresh();
+    }
+  });
+
   extend(IndexPage.prototype, 'navItems', (items) => {
     const user = app.session.user;
 


### PR DESCRIPTION


<!--
IMPORTANT: We LOVE seeing new pull requests, they excite us every single time they are submitted! As we have an obligation to maintain a healthy code standard, quality, and extensions, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #234**

**Changes proposed in this pull request:**
clear and refresh discussions when navigating to /private from a non IndexPage. `flarum/core` only clears this if the previous route is a IndexPage:

https://github.com/flarum/framework/blob/8e70ea4e36e57eeb25efac46467d26d0e526eb04/framework/core/js/src/forum/components/IndexPage.tsx#L42-L44

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).

**Required changes:**

- [ ] Related [Flarum core extension PR's](https://github.com/flarum/core/pulls): (Omit this section if irrelevant)
