### PR TITLE
[2.x] fix: refresh discussion list when navigating to /private from non-IndexPage

### DIFF
--- a/js/src/forum/pages/PrivateDiscussionsPage.js
+++ b/js/src/forum/pages/PrivateDiscussionsPage.js
@@ -8,6 +8,13 @@ import PrivateComposing from './PrivateComposing';
 import PrivateHero from '../components/PrivateHero';
 
 export default function PrivateDiscussionsPage() {
+  extend(IndexPage.prototype, 'oninit', function () {
+    if (app.current.get('routeName') === 'byobuPrivate' && !app.previous.matches(IndexPage)) {
+      app.discussions.clear();
+      app.discussions.refresh();
+    }
+  });
+
   extend(IndexSidebar.prototype, 'navItems', (items) => {
     const user = app.session.user;
 


### PR DESCRIPTION
2.x equivalent to #244 

**Fixes #0000**

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).

**Required changes:**

- [ ] Related [Flarum core extension PR's](https://github.com/flarum/core/pulls): (Omit this section if irrelevant)
