### PR TITLE
fix: refresh discussion list when returning to index after visiting private discussions via non-IndexPage

### DIFF
--- a/js/src/forum/pages/PrivateDiscussionsPage.js
+++ b/js/src/forum/pages/PrivateDiscussionsPage.js
@@ -7,10 +7,18 @@ import DiscussionListState from 'flarum/forum/states/DiscussionListState';
 import PrivateComposing from './PrivateComposing';
 import PrivateHero from '../components/PrivateHero';
 
+let lastIndexPageRouteName = null;
+
 export default function PrivateDiscussionsPage() {
   extend(IndexPage.prototype, 'oninit', function () {
-    if (app.current.get('routeName') === 'byobuPrivate' && !app.previous.matches(IndexPage)) {
+    const routeName = app.current.get('routeName');
+    const prevIndexPageRoute = lastIndexPageRouteName;
+    lastIndexPageRouteName = routeName;
+
+    if (routeName === 'byobuPrivate' && !app.previous.matches(IndexPage)) {
       app.discussions.clear();
+      app.discussions.refresh();
+    } else if (routeName !== 'byobuPrivate' && prevIndexPageRoute === 'byobuPrivate' && !app.previous.matches(IndexPage)) {
       app.discussions.refresh();
     }
   });


### PR DESCRIPTION
2.x port of #249 

**Fixes #0000**

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).

**Required changes:**

- [ ] Related [Flarum core extension PR's](https://github.com/flarum/core/pulls): (Omit this section if irrelevant)
