### PR TITLE
[2.x] chore: point phpunit configs at vendored schema

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ js/node_modules
 vendor/
 composer.lock
 .phpunit.result.cache
+.phpunit.cache

--- a/tests/phpunit.integration.xml
+++ b/tests/phpunit.integration.xml
@@ -1,21 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd"
+    xsi:noNamespaceSchemaLocation="../vendor/phpunit/phpunit/phpunit.xsd"
+    backupGlobals="false"
+    cacheDirectory=".phpunit.cache"
+    backupStaticProperties="false"
     colors="true"
     processIsolation="true"
     stopOnFailure="false"
 >
-    <coverage processUncoveredFiles="true">
+    <source>
         <include>
             <directory suffix=".php">../src/</directory>
         </include>
-    </coverage>
+    </source>
     <testsuites>
         <testsuite name="Flarum Integration Tests">
             <directory suffix="Test.php">./integration</directory>
-             <exclude>./integration/tmp</exclude>
-             <exclude>./integration/api/AbstractCreatePrivateDiscussionTest.php</exclude>
+            <exclude>./integration/tmp</exclude>
+            <exclude>./integration/api/AbstractCreatePrivateDiscussionTest.php</exclude>
         </testsuite>
     </testsuites>
 </phpunit>

--- a/tests/phpunit.unit.xml
+++ b/tests/phpunit.unit.xml
@@ -1,27 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+    xsi:noNamespaceSchemaLocation="../vendor/phpunit/phpunit/phpunit.xsd"
     backupGlobals="false"
-    backupStaticAttributes="false"
+    cacheDirectory=".phpunit.cache"
+    backupStaticProperties="false"
     colors="true"
-    convertErrorsToExceptions="true"
-    convertNoticesToExceptions="true"
-    convertWarningsToExceptions="true"
     processIsolation="false"
     stopOnFailure="false"
 >
-    <coverage processUncoveredFiles="true">
+    <source>
         <include>
             <directory suffix=".php">../src/</directory>
         </include>
-    </coverage>
+    </source>
     <testsuites>
         <testsuite name="Flarum Unit Tests">
             <directory suffix="Test.php">./unit</directory>
         </testsuite>
     </testsuites>
-    <listeners>
-        <listener class="\Mockery\Adapter\Phpunit\TestListener" />
-    </listeners>
 </phpunit>


### PR DESCRIPTION
The phpunit configs were pointing at pinned remote schema URLs — `11.5` for integration, `9.3` for unit — while the rest of the 2.x extensions reference the vendored `phpunit.xsd`. Switched both over so the schema tracks whatever PHPUnit version is actually installed, and there's no network fetch to validate a config.

The unit config was still PHPUnit 9-era and didn't validate against the 12 schema, so that needed cleaning up too:

- `<coverage>` -> `<source>` (deprecated as a source-file container in 10)
- `backupStaticAttributes` -> `backupStaticProperties` (renamed in 10)
- dropped the `convert*ToExceptions` attributes (removed in 10)
- dropped the `<listeners>` block — the listener API went away in 10, and `mockery/mockery` isn't a dependency here so that listener wasn't resolvable anyway

Added `cacheDirectory`/`backupGlobals`/`backupStaticProperties` to match the sibling extensions, and `.phpunit.cache` to `.gitignore` since `cacheDirectory` is new to these configs.