### PR TITLE
[2.x] fix: byobu gambit returning no results, plus broken allows-pd filter

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -76,6 +76,7 @@
     "require-dev": {
         "fof/split": "^2.0.0",
         "flarum/flags": "^2.0.0",
+        "flarum/nicknames": "^2.0.0",
         "flarum/phpstan": "^2.0.0",
         "flarum/testing": "^2.0.0"
     },

--- a/resources/locale/en.yml
+++ b/resources/locale/en.yml
@@ -154,7 +154,9 @@ fof-byobu:
     gambits:
       byobu:
         key: byobu
+        hint: username of a recipient
       private:
         key: private
       allows-pd:
         key: allows-pd
+        hint: "yes"

--- a/resources/locale/en.yml
+++ b/resources/locale/en.yml
@@ -154,7 +154,7 @@ fof-byobu:
     gambits:
       byobu:
         key: byobu
-        hint: username of a recipient
+        hint: username or display name of a recipient
       private:
         key: private
       allows-pd:

--- a/src/Events/SearchingRecipient.php
+++ b/src/Events/SearchingRecipient.php
@@ -15,7 +15,7 @@ use Flarum\Search\SearchState;
 
 class SearchingRecipient
 {
-    public function __construct(public SearchState $search, public array $matches, public bool $negate)
+    public function __construct(public SearchState $search, public array|string $matches, public bool $negate)
     {
     }
 }

--- a/src/Filters/Discussion/ByobuFilter.php
+++ b/src/Filters/Discussion/ByobuFilter.php
@@ -16,6 +16,7 @@ use Flarum\Search\Database\DatabaseSearchState;
 use Flarum\Search\Filter\FilterInterface;
 use Flarum\Search\SearchState;
 use Flarum\User\User;
+use Flarum\User\UserRepository;
 use FoF\Byobu\Database\RecipientsConstraint;
 
 /**
@@ -27,7 +28,7 @@ class ByobuFilter implements FilterInterface
 {
     use RecipientsConstraint;
 
-    public function __construct(protected SlugManager $slugManager)
+    public function __construct(protected SlugManager $slugManager, protected UserRepository $users)
     {
     }
 
@@ -44,9 +45,9 @@ class ByobuFilter implements FilterInterface
             return;
         }
 
-        try {
-            $user = $this->slugManager->forResource(User::class)->fromSlug($username, $state->getActor());
-        } catch (\Illuminate\Database\Eloquent\ModelNotFoundException $e) {
+        $user = $this->resolveUser($username, $state->getActor());
+
+        if ($user === null) {
             // If the user doesn't exist, return no results by adding an impossible condition
             $state->getQuery()->whereRaw('1 = 0');
 
@@ -56,6 +57,50 @@ class ByobuFilter implements FilterInterface
         $state->getQuery()->where(function ($query) use ($user) {
             $this->forRecipient($query, [], $user->id);
         });
+    }
+
+    /**
+     * Resolve the gambit value to a user.
+     *
+     * Three lookups are needed, because what a person types is whatever the
+     * forum shows them, which depends on configuration:
+     *
+     *  1. The slug driver. Under the default utf8_username driver a username
+     *     *is* the slug, but id_with_display_name expects "133-karaok" and a
+     *     third-party driver may produce any shape at all.
+     *  2. The username, for when the slug driver doesn't accept a bare one.
+     *  3. The nickname, when a display-name driver backed by that column is in
+     *     use (flarum/nicknames), since the nickname is what the UI displays
+     *     and therefore what gets typed.
+     *
+     * Display names themselves can't be matched directly: DriverInterface only
+     * maps user -> string, with no reverse lookup, and drivers may transform
+     * the value (the nickname driver strips brackets and inserts zero-width
+     * spaces), so a computed display name need not equal any stored column.
+     */
+    protected function resolveUser(string $username, User $actor): ?User
+    {
+        try {
+            return $this->slugManager->forResource(User::class)->fromSlug($username, $actor);
+        } catch (\Throwable) {
+            // Not a valid slug for the configured driver; fall through.
+        }
+
+        $id = $this->users->getIdForUsername($username, $actor);
+
+        if ($id !== null) {
+            return $this->users->query()->find($id);
+        }
+
+        // Only when a nickname column is actually present, so this keeps working
+        // whether or not flarum/nicknames is installed.
+        $query = $this->users->query();
+
+        if ($query->getConnection()->getSchemaBuilder()->hasColumn('users', 'nickname')) {
+            return $query->where('nickname', $username)->first();
+        }
+
+        return null;
     }
 
     public function getFilterKey(): string

--- a/src/Filters/Discussion/ByobuFilter.php
+++ b/src/Filters/Discussion/ByobuFilter.php
@@ -15,6 +15,7 @@ use Flarum\Http\SlugManager;
 use Flarum\Search\Database\DatabaseSearchState;
 use Flarum\Search\Filter\FilterInterface;
 use Flarum\Search\SearchState;
+use Flarum\User\IdWithDisplayNameSlugDriver;
 use Flarum\User\User;
 use Flarum\User\UserRepository;
 use FoF\Byobu\Database\RecipientsConstraint;
@@ -65,13 +66,20 @@ class ByobuFilter implements FilterInterface
      * Three lookups are needed, because what a person types is whatever the
      * forum shows them, which depends on configuration:
      *
-     *  1. The slug driver. Under the default utf8_username driver a username
-     *     *is* the slug, but id_with_display_name expects "133-karaok" and a
-     *     third-party driver may produce any shape at all.
-     *  2. The username, for when the slug driver doesn't accept a bare one.
-     *  3. The nickname, when a display-name driver backed by that column is in
+     *  1. The username, which is what the gambit documents and what the default
+     *     utf8_username slug driver would resolve anyway.
+     *  2. The nickname, when a display-name driver backed by that column is in
      *     use (flarum/nicknames), since the nickname is what the UI displays
      *     and therefore what gets typed.
+     *  3. The slug driver, for an actual slug such as "133-karaok" under
+     *     id_with_display_name, or whatever shape a third-party driver uses.
+     *
+     * The column lookups deliberately come first, and IdWithDisplayNameSlugDriver
+     * is skipped for non-numeric values. That driver passes the leading segment
+     * straight to findOrFail(), so on PostgreSQL a bare name is compared against
+     * the integer id column, which raises — and inside a transaction it poisons
+     * every later statement. MySQL and SQLite silently coerce, so the difference
+     * is invisible there.
      *
      * Display names themselves can't be matched directly: DriverInterface only
      * maps user -> string, with no reverse lookup, and drivers may transform
@@ -80,12 +88,6 @@ class ByobuFilter implements FilterInterface
      */
     protected function resolveUser(string $username, User $actor): ?User
     {
-        try {
-            return $this->slugManager->forResource(User::class)->fromSlug($username, $actor);
-        } catch (\Throwable) {
-            // Not a valid slug for the configured driver; fall through.
-        }
-
         $id = $this->users->getIdForUsername($username, $actor);
 
         if ($id !== null) {
@@ -94,13 +96,28 @@ class ByobuFilter implements FilterInterface
 
         // Only when a nickname column is actually present, so this keeps working
         // whether or not flarum/nicknames is installed.
-        $query = $this->users->query();
+        if ($this->users->query()->getConnection()->getSchemaBuilder()->hasColumn('users', 'nickname')) {
+            $user = $this->users->query()->where('nickname', $username)->first();
 
-        if ($query->getConnection()->getSchemaBuilder()->hasColumn('users', 'nickname')) {
-            return $query->where('nickname', $username)->first();
+            if ($user !== null) {
+                return $user;
+            }
         }
 
-        return null;
+        $driver = $this->slugManager->forResource(User::class);
+
+        // IdWithDisplayNameSlugDriver treats the leading segment as an id, so a
+        // non-numeric value would be compared against the integer id column.
+        // Skip it rather than let the driver issue a query that errors.
+        if ($driver instanceof IdWithDisplayNameSlugDriver && !preg_match('/^\d+(-|$)/', $username)) {
+            return null;
+        }
+
+        try {
+            return $driver->fromSlug($username, $actor);
+        } catch (\Throwable) {
+            return null;
+        }
     }
 
     public function getFilterKey(): string

--- a/src/Filters/User/AllowsPdFilter.php
+++ b/src/Filters/User/AllowsPdFilter.php
@@ -60,6 +60,6 @@ class AllowsPdFilter implements FilterInterface
 
     public function getFilterKey(): string
     {
-        return 'byobu';
+        return 'allows-pd';
     }
 }

--- a/tests/integration/api/AllowsPdFilterTest.php
+++ b/tests/integration/api/AllowsPdFilterTest.php
@@ -1,0 +1,118 @@
+<?php
+
+/*
+ * This file is part of fof/byobu.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FoF\Byobu\Tests\integration\api;
+
+use Flarum\Group\Group;
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\Testing\integration\TestCase;
+use Flarum\User\User;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * Covers {@see \FoF\Byobu\Filters\User\AllowsPdFilter}, the user searcher
+ * filter behind the recipient picker.
+ *
+ * The filter hides users who have opted out of private discussions
+ * (blocks_byobu_pd), unless the actor holds
+ * discussion.startPrivateDiscussionWithBlockers.
+ *
+ * Fixtures:
+ *   1 admin, 2 normal, 3 alice, 4 blocker (blocks_byobu_pd = 1)
+ */
+class AllowsPdFilterTest extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->extension('fof-byobu');
+
+        $this->prepareDatabase([
+            User::class => [
+                $this->normalUser(),
+                ['id' => 3, 'username' => 'alice',   'email' => 'alice@example.com',   'password' => 'too-obscure', 'is_email_confirmed' => 1],
+                ['id' => 4, 'username' => 'blocker', 'email' => 'blocker@example.com', 'password' => 'too-obscure', 'is_email_confirmed' => 1, 'blocks_byobu_pd' => 1],
+            ],
+        ]);
+    }
+
+    protected function grantPermission(string $permission, int $groupId = Group::MEMBER_ID): void
+    {
+        $this->prepareDatabase([
+            'group_permission' => [
+                ['group_id' => $groupId, 'permission' => $permission],
+            ],
+        ]);
+    }
+
+    /**
+     * GET /api/users with the given filter, returning matched usernames.
+     */
+    protected function filterUsernames(array $filter, ?int $actorId = null): array
+    {
+        $response = $this->send(
+            $this->request('GET', '/api/users', array_filter([
+                'authenticatedAs' => $actorId,
+            ]))->withQueryParams(['filter' => $filter])
+        );
+
+        $this->assertEquals(200, $response->getStatusCode(), 'User search request failed');
+
+        $body = json_decode($response->getBody()->getContents(), true);
+
+        return array_map(
+            fn ($user) => $user['attributes']['username'],
+            $body['data'] ?? []
+        );
+    }
+
+    #[Test]
+    public function filterHidesUsersWhoBlockPrivateDiscussions()
+    {
+        $usernames = $this->filterUsernames(['allows-pd' => 'true'], 2);
+
+        $this->assertContains('alice', $usernames);
+        $this->assertNotContains('blocker', $usernames, 'Users who block PDs must be filtered out');
+    }
+
+    #[Test]
+    public function filterIsBypassedForActorsAllowedToMessageBlockers()
+    {
+        $this->grantPermission('discussion.startPrivateDiscussionWithBlockers');
+
+        $usernames = $this->filterUsernames(['allows-pd' => 'true'], 2);
+
+        $this->assertContains('blocker', $usernames, 'Privileged actors may see blocking users');
+    }
+
+    #[Test]
+    public function negatedFilterReturnsOnlyBlockingUsers()
+    {
+        $usernames = $this->filterUsernames(['-allows-pd' => 'true'], 2);
+
+        $this->assertContains('blocker', $usernames);
+        $this->assertNotContains('alice', $usernames);
+    }
+
+    #[Test]
+    public function unfilteredUserSearchStillIncludesBlockingUsers()
+    {
+        // Without the filter the opt-out must not apply — it is scoped to the
+        // recipient picker, not to user search in general.
+        $usernames = $this->filterUsernames([], 2);
+
+        $this->assertContains('alice', $usernames);
+        $this->assertContains('blocker', $usernames);
+    }
+}

--- a/tests/integration/api/ByobuFilterWithNicknamesTest.php
+++ b/tests/integration/api/ByobuFilterWithNicknamesTest.php
@@ -1,0 +1,102 @@
+<?php
+
+/*
+ * This file is part of fof/byobu.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FoF\Byobu\Tests\integration\api;
+
+use Carbon\Carbon;
+use Flarum\Discussion\Discussion;
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\Testing\integration\TestCase;
+use Flarum\User\User;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * The byobu gambit resolves whatever name the forum displays, which with
+ * flarum/nicknames enabled is the nickname rather than the username.
+ *
+ * Display names cannot be matched directly — DisplayName\DriverInterface only
+ * maps user -> string with no reverse lookup — so
+ * {@see \FoF\Byobu\Filters\Discussion\ByobuFilter::resolveUser()} falls back to
+ * the nickname column when one is present.
+ *
+ * Fixtures:
+ *   1 admin, 2 normal, 3 alice (nickname "Ali"), 4 bob (no nickname)
+ *   Discussion 2 is private between alice and bob.
+ */
+class ByobuFilterWithNicknamesTest extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->extension('fof-byobu', 'flarum-nicknames');
+
+        $now = Carbon::now();
+
+        $this->prepareDatabase([
+            User::class => [
+                $this->normalUser(),
+                ['id' => 3, 'username' => 'alice', 'nickname' => 'Ali', 'email' => 'alice@example.com', 'password' => 'too-obscure', 'is_email_confirmed' => 1],
+                ['id' => 4, 'username' => 'bob',   'nickname' => null,  'email' => 'bob@example.com',   'password' => 'too-obscure', 'is_email_confirmed' => 1],
+            ],
+            Discussion::class => [
+                ['id' => 2, 'title' => 'Alice and Bob', 'user_id' => 3, 'created_at' => $now, 'is_private' => 1, 'comment_count' => 1],
+            ],
+            'recipients' => [
+                ['discussion_id' => 2, 'user_id' => 3, 'group_id' => null, 'removed_at' => null, 'created_at' => $now, 'updated_at' => $now],
+                ['discussion_id' => 2, 'user_id' => 4, 'group_id' => null, 'removed_at' => null, 'created_at' => $now, 'updated_at' => $now],
+            ],
+        ]);
+
+        $this->setting('display_name_driver', 'nickname');
+    }
+
+    protected function filterIds(string $value, int $actorId): array
+    {
+        $response = $this->send(
+            $this->request('GET', '/api/discussions', ['authenticatedAs' => $actorId])
+                ->withQueryParams(['filter' => ['byobu' => $value]])
+        );
+
+        $this->assertEquals(200, $response->getStatusCode(), 'Search request failed');
+
+        $body = json_decode($response->getBody()->getContents(), true);
+
+        return array_map(fn ($discussion) => (int) $discussion['id'], $body['data'] ?? []);
+    }
+
+    #[Test]
+    public function byobuFilterResolvesANickname()
+    {
+        // "Ali" is what the forum displays for alice, so it is what a user types.
+        $this->assertContains(2, $this->filterIds('Ali', 4));
+    }
+
+    #[Test]
+    public function byobuFilterStillResolvesTheUsernameWhenANicknameIsSet()
+    {
+        $this->assertContains(2, $this->filterIds('alice', 4));
+    }
+
+    #[Test]
+    public function byobuFilterResolvesUsersWithoutANickname()
+    {
+        $this->assertContains(2, $this->filterIds('bob', 3));
+    }
+
+    #[Test]
+    public function byobuFilterWithAnUnknownNicknameReturnsNoResults()
+    {
+        $this->assertSame([], $this->filterIds('NotANickname', 4));
+    }
+}

--- a/tests/integration/api/DiscussionFiltersTest.php
+++ b/tests/integration/api/DiscussionFiltersTest.php
@@ -1,0 +1,203 @@
+<?php
+
+/*
+ * This file is part of fof/byobu.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FoF\Byobu\Tests\integration\api;
+
+use Carbon\Carbon;
+use Flarum\Discussion\Discussion;
+use Flarum\Group\Group;
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\Testing\integration\TestCase;
+use Flarum\User\User;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * Covers the two discussion searcher filters:
+ *
+ *  - filter[byobu]=<username>  {@see \FoF\Byobu\Filters\Discussion\ByobuFilter}
+ *  - filter[private]=true      {@see \FoF\Byobu\Filters\Discussion\PrivacyFilter}
+ *
+ * These are addressed by filter key rather than by gambit string. Gambit
+ * parsing ("byobu:bob") happens client-side in the JS IGambit classes, which
+ * translate to the filter keys before the request is made — filter[q] never
+ * sees gambit syntax on the server.
+ *
+ * Fixtures:
+ *   1 admin, 2 normal, 3 alice, 4 bob, 5 outsider
+ *   Staff group (10) contains alice and bob.
+ *
+ *   Discussion 1 "Public one"    — not private, no recipients
+ *   Discussion 2 "Alice and Bob" — private, recipient users alice + bob
+ *   Discussion 3 "Staff only"    — private, recipient group Staff
+ *   Discussion 4 "Alice left"    — private, alice's recipient row is soft-removed
+ */
+class DiscussionFiltersTest extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->extension('fof-byobu');
+
+        $now = Carbon::now();
+
+        $this->prepareDatabase([
+            User::class => [
+                $this->normalUser(),
+                ['id' => 3, 'username' => 'alice',    'email' => 'alice@example.com',    'password' => 'too-obscure', 'is_email_confirmed' => 1],
+                ['id' => 4, 'username' => 'bob',      'email' => 'bob@example.com',      'password' => 'too-obscure', 'is_email_confirmed' => 1],
+                ['id' => 5, 'username' => 'outsider', 'email' => 'outsider@example.com', 'password' => 'too-obscure', 'is_email_confirmed' => 1],
+            ],
+            Group::class => [
+                ['id' => 10, 'name_singular' => 'Staff', 'name_plural' => 'Staff', 'color' => null, 'icon' => null, 'is_hidden' => 0],
+            ],
+            'group_user' => [
+                ['user_id' => 3, 'group_id' => 10],
+                ['user_id' => 4, 'group_id' => 10],
+            ],
+            Discussion::class => [
+                ['id' => 1, 'title' => 'Public one',    'user_id' => 5, 'created_at' => $now, 'is_private' => 0, 'comment_count' => 1],
+                ['id' => 2, 'title' => 'Alice and Bob', 'user_id' => 3, 'created_at' => $now, 'is_private' => 1, 'comment_count' => 1],
+                ['id' => 3, 'title' => 'Staff only',    'user_id' => 3, 'created_at' => $now, 'is_private' => 1, 'comment_count' => 1],
+                ['id' => 4, 'title' => 'Alice left',    'user_id' => 4, 'created_at' => $now, 'is_private' => 1, 'comment_count' => 1],
+            ],
+            'recipients' => [
+                ['discussion_id' => 2, 'user_id' => 3, 'group_id' => null, 'removed_at' => null, 'created_at' => $now, 'updated_at' => $now],
+                ['discussion_id' => 2, 'user_id' => 4, 'group_id' => null, 'removed_at' => null, 'created_at' => $now, 'updated_at' => $now],
+                ['discussion_id' => 3, 'user_id' => null, 'group_id' => 10, 'removed_at' => null, 'created_at' => $now, 'updated_at' => $now],
+                // Alice was removed from discussion 4; bob remains.
+                ['discussion_id' => 4, 'user_id' => 3, 'group_id' => null, 'removed_at' => $now, 'created_at' => $now, 'updated_at' => $now],
+                ['discussion_id' => 4, 'user_id' => 4, 'group_id' => null, 'removed_at' => null, 'created_at' => $now, 'updated_at' => $now],
+            ],
+        ]);
+    }
+
+    /**
+     * GET /api/discussions with the given filter, returning matched ids.
+     */
+    protected function filterIds(array $filter, ?int $actorId = null): array
+    {
+        $response = $this->send(
+            $this->request('GET', '/api/discussions', array_filter([
+                'authenticatedAs' => $actorId,
+            ]))->withQueryParams(['filter' => $filter])
+        );
+
+        $this->assertEquals(200, $response->getStatusCode(), 'Search request failed');
+
+        $body = json_decode($response->getBody()->getContents(), true);
+
+        return array_map(fn ($discussion) => (int) $discussion['id'], $body['data'] ?? []);
+    }
+
+    // -------------------------------------------------------------------------
+    // ByobuFilter — filter[byobu]
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function byobuFilterReturnsDiscussionsWhereUserIsADirectRecipient()
+    {
+        $ids = $this->filterIds(['byobu' => 'bob'], 4);
+
+        $this->assertContains(2, $ids);
+        $this->assertContains(4, $ids);
+        $this->assertNotContains(1, $ids, 'Public discussion must not match a recipient filter');
+    }
+
+    #[Test]
+    public function byobuFilterExcludesSoftRemovedRecipients()
+    {
+        $ids = $this->filterIds(['byobu' => 'alice'], 3);
+
+        $this->assertContains(2, $ids, 'Alice is still a recipient on discussion 2');
+        $this->assertNotContains(4, $ids, 'Alice was removed from discussion 4 and must not match');
+    }
+
+    #[Test]
+    public function byobuFilterMatchesOnlyDirectUserRowsNotGroupMembership()
+    {
+        // Discussion 3 is addressed to the Staff group, which bob belongs to,
+        // but ByobuFilter::forRecipient() is called with an empty group list.
+        $ids = $this->filterIds(['byobu' => 'bob'], 4);
+
+        $this->assertNotContains(3, $ids, 'Group-addressed discussions are not matched by the byobu filter');
+    }
+
+    #[Test]
+    public function byobuFilterWithUnknownUsernameReturnsNoResults()
+    {
+        $this->assertSame([], $this->filterIds(['byobu' => 'nobodyhere'], 3));
+    }
+
+    #[Test]
+    public function byobuFilterWithEmptyValueReturnsNoResults()
+    {
+        $this->assertSame([], $this->filterIds(['byobu' => ''], 3));
+    }
+
+    #[Test]
+    public function byobuFilterDoesNotLeakDiscussionsTheActorCannotSee()
+    {
+        // Outsider receives none of the private discussions. Filtering by bob's
+        // username must not expose bob's private discussions to them.
+        $ids = $this->filterIds(['byobu' => 'bob'], 5);
+
+        $this->assertNotContains(2, $ids);
+        $this->assertNotContains(4, $ids);
+    }
+
+    // -------------------------------------------------------------------------
+    // PrivacyFilter — filter[private]
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function privateFilterReturnsOnlyDiscussionsTheActorReceives()
+    {
+        $ids = $this->filterIds(['private' => 'true'], 3);
+
+        $this->assertContains(2, $ids);
+        $this->assertContains(3, $ids, 'Group recipients must match via the actor groups');
+        $this->assertNotContains(4, $ids, 'Removed recipient must not match');
+        $this->assertNotContains(1, $ids, 'Public discussion is not private');
+    }
+
+    #[Test]
+    public function privateFilterMatchesGroupRecipients()
+    {
+        $ids = $this->filterIds(['private' => 'true'], 4);
+
+        $this->assertContains(3, $ids, 'Bob is in Staff, which receives discussion 3');
+    }
+
+    #[Test]
+    public function privateFilterReturnsNothingForAUserWithNoPrivateDiscussions()
+    {
+        $ids = $this->filterIds(['private' => 'true'], 5);
+
+        $this->assertNotContains(2, $ids);
+        $this->assertNotContains(3, $ids);
+        $this->assertNotContains(4, $ids);
+    }
+
+    #[Test]
+    public function privateFilterIsANoopForGuests()
+    {
+        // PrivacyFilter returns early for guests, leaving normal visibility
+        // scoping to decide — a guest sees the public discussion and no more.
+        $ids = $this->filterIds(['private' => 'true']);
+
+        $this->assertNotContains(2, $ids);
+        $this->assertNotContains(3, $ids);
+        $this->assertNotContains(4, $ids);
+    }
+}

--- a/tests/integration/api/DiscussionFiltersTest.php
+++ b/tests/integration/api/DiscussionFiltersTest.php
@@ -146,6 +146,25 @@ class DiscussionFiltersTest extends TestCase
     }
 
     #[Test]
+    public function byobuFilterAcceptsAUsernameUnderTheIdWithDisplayNameSlugDriver()
+    {
+        // Under this driver the slug is "3-alice", so a bare username does not
+        // resolve through the slug manager and must fall back to a username
+        // lookup. Regression test: previously returned zero results.
+        $this->setting('slug_driver_Flarum\User\User', 'id_with_display_name');
+
+        $this->assertContains(2, $this->filterIds(['byobu' => 'alice'], 3));
+    }
+
+    #[Test]
+    public function byobuFilterStillAcceptsASlugUnderTheIdWithDisplayNameSlugDriver()
+    {
+        $this->setting('slug_driver_Flarum\User\User', 'id_with_display_name');
+
+        $this->assertContains(2, $this->filterIds(['byobu' => '3-alice'], 3));
+    }
+
+    #[Test]
     public function byobuFilterDoesNotLeakDiscussionsTheActorCannotSee()
     {
         // Outsider receives none of the private discussions. Filtering by bob's


### PR DESCRIPTION
Fixes #252

Started as the missing gambit hint from #252. Testing that against a real forum turned up three further bugs, all in the same area.

### `byobu:<name>` returned nothing on most forums

The headline bug. `ByobuFilter` resolved the gambit value only through the slug manager, so on any forum not using the default `utf8_username` slug driver the lookup threw and the filter fell into its `1 = 0` branch — zero results, no error.

On a forum using `id_with_display_name`, the slug for user 133 is `133-karaok`, so `byobu:Karaok` could never match. Verified against a real forum: the user had five live recipient rows and four shared discussions with the actor, and the gambit returned nothing.

It now tries the slug driver, then the username, then the nickname column when one is present:

- **Slug** — the default driver makes a username *the* slug, so this stays the fast path.
- **Username** — for drivers that don't accept a bare one.
- **Nickname** — with `flarum/nicknames` enabled this is what the forum displays, so it is what gets typed.

Display names can't be matched directly: `DisplayName\DriverInterface` only maps user -> string with no reverse lookup, and drivers may transform the value (the nickname driver strips brackets and inserts zero-width spaces after dots), so a computed display name need not equal any stored column. Matching the underlying columns is the tractable approach, and it keeps working for third-party slug drivers of any shape.

The lookups run username -> nickname -> slug driver, in that order, and the id-based slug driver is skipped for non-numeric values. `IdWithDisplayNameSlugDriver` passes the leading slug segment straight to `findOrFail()`, so a bare username ends up compared against the integer `id` column. PostgreSQL raises on that and, because the request runs in a transaction, every later statement is poisoned; MySQL and SQLite silently coerce, which is why this surfaced only on the pgsql CI job. Verified against PostgreSQL 10, MySQL 8 and SQLite.

`Throwable` is caught rather than just `ModelNotFoundException` — slug drivers are third-party code being fed arbitrary search input, and one blowing up shouldn't 500 the whole search.

Hint updated to "username or display name of a recipient" to match.

### Missing hint translations

`KeyValueGambit` declares `hint()` abstract, and both `ByobuGambit` and `AllowsPdGambit` implement it by looking up `fof-byobu.lib.gambits.*.hint` — but neither key was ever added to `en.yml`, so the translator echoed the raw key into the search modal.

The issue only mentions the byobu gambit; allows-pd had the same missing key. `PrivacyGambit` is a `BooleanGambit`, so it has no hint and needs nothing. The `"yes"` is quoted deliberately; unquoted, YAML parses it as boolean `true`.

### AllowsPdFilter threw a 500 on every request

`SearchingRecipient` declared `array $matches`, but `FilterManager` passes the scalar filter value, so any request reaching the filter died with a `TypeError`. Widened to `array|string` — it's a public extension-facing event with no listeners in this repo, so widening won't break anyone already type-hinting `array`.

### AllowsPdFilter was never invoked

`getFilterKey()` returned `'byobu'`, but the JS gambit's `filterKey()` is `'allows-pd'` and `UserSearchSource` already sends `filter: { 'allows-pd': true }` — the frontend was right and the PHP key was wrong, so the filter never ran.

The practical effect: **users who opted out of private discussions were still listed as selectable recipients**. Renaming a filter key is technically breaking, but since the old key threw a `TypeError` whenever it was used, nothing can have depended on it working.

### Tests

No coverage existed for any of the filters. Added `DiscussionFiltersTest`, `AllowsPdFilterTest` and `ByobuFilterWithNicknamesTest`, covering recipient matching, soft-removed recipients, group vs direct recipients, unknown and empty values, guest handling, negation, the `startPrivateDiscussionWithBlockers` bypass, both slug drivers, and nickname resolution.

The slug-driver and nickname tests were both confirmed to fail against the pre-fix code, so they're genuine regression tests.

`flarum/nicknames` added as a dev dependency to cover the nickname path — its migration is what creates the column the fallback keys off.

Note the tests address the filters by filter key, not gambit string: gambit parsing is client-side in the JS `IGambit` classes, which translate to filter keys before the request, so `filter[q]` never sees gambit syntax on the server.

Suite goes from 33 to 53 tests. PHPStan clean.
