### PR TITLE
[2.x] perf: lazy load byobu route components

### DIFF
--- a/js/src/forum/extend.ts
+++ b/js/src/forum/extend.ts
@@ -12,8 +12,6 @@ import PrivateDiscussionReplyNotification from './notifications/PrivateDiscussio
 import PrivateDiscussionUserLeftNotification from './notifications/PrivateDiscussionUserLeftNotification';
 import PrivateDiscussionAddedNotification from './notifications/PrivateDiscussionAddedNotification';
 import PrivateDiscussionMadePublicNotification from './notifications/PrivateDiscussionMadePublicNotification';
-import PrivateComposerPage from './components/PrivateComposerPage';
-import PrivateDiscussionsUserPage from './pages/PrivateDiscussionsUserPage';
 
 export default [
   ...commonExtend,
@@ -23,9 +21,9 @@ export default [
     .add('madePublic', MadePublic),
 
   new Extend.Routes() //
-    .add('byobuUserPrivate', '/u/:username/private', PrivateDiscussionsUserPage)
+    .add('byobuUserPrivate', '/u/:username/private', () => import('./pages/PrivateDiscussionsUserPage'))
     .add('byobuPrivate', '/private', IndexPage)
-    .add('byobuComposer', '/private/composer', PrivateComposerPage),
+    .add('byobuComposer', '/private/composer', () => import('./components/PrivateComposerPage')),
 
   new Extend.Model(Discussion)
     .hasMany<User>('recipientUsers')


### PR DESCRIPTION
Registers the two byobu-owned route components as async factories, so they're fetched on demand rather than shipped in the eager forum payload.

```diff
-    .add('byobuUserPrivate', '/u/:username/private', PrivateDiscussionsUserPage)
+    .add('byobuUserPrivate', '/u/:username/private', () => import('./pages/PrivateDiscussionsUserPage'))
     .add('byobuPrivate', '/private', IndexPage)
-    .add('byobuComposer', '/private/composer', PrivateComposerPage),
+    .add('byobuComposer', '/private/composer', () => import('./components/PrivateComposerPage')),
```

`Extend.Routes().add()` accepts an `AsyncNewComponent` factory, and `jsDirectory()` is already registered in `extend.php`, so the emitted chunks are served with no backend change.

## Result

Forum bundle **25.7 KB → 23.3 KB**, with two new chunks:

| Chunk | Size |
| --- | --- |
| `forum/pages/PrivateDiscussionsUserPage.js` | 1.77 KB |
| `forum/components/PrivateComposerPage.js` | 1.55 KB |

`PrivateComposing` and `canStartPrivateDiscussion` stay in the main bundle — they're also reachable from `PrivateDiscussionsPage` and `extendUserComponents`, which remain eager. Only the two page components and their exclusive dependencies (`PrivateDiscussionListState`, `PrivateDiscussionList`) moved.

## Why `/private` isn't included

`/private` is routed to core's `IndexPage`, not a byobu component, so there's no byobu page there to defer. Its behaviour comes from `extend`/`override` hooks registered at initializer time, which have to run eagerly. Deferring it would mean first reworking the route onto a byobu-owned page component — worth doing, but a refactor that also touches the PHP route registration, so it belongs in its own PR.

## Testing

- `yarn build` — compiles, both chunks emitted
- `yarn format` — no changes
- Manually verified `/u/:username/private` (sort dropdown, start-PD button) and `/private/composer` (with `content`/`recipientUsers`/`title`/`redirect` params, and as a guest → `LogInModal` + redirect)

No behaviour change intended — purely a change in *when* these components load.

## Note for after merge

This alters chunk output, so please confirm flarum-bot commits the regenerated `dist`/`dist-typings` on `2.x`. Only `js/src` is changed here.

Docs reference: https://docs.flarum.org/2.x/extend/code-splitting